### PR TITLE
fix: document ProgressMessage

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -403,6 +403,15 @@ interface TextContent {
 }
 
 /**
+ * Progress messages from the LLM. 
+ */
+interface ProgressContent {
+    type: 'progress';
+    state: 'running|finished';
+    text: string;
+}
+
+/**
  * A reason started from the LLM
  *
  */


### PR DESCRIPTION
`ProgressMessage` was not documented in the protocol. It looks like there are only two possible states, `running` and `finished`.