### PR TITLE
Add `openai-chat` api for custom providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## Unreleased
 
 - Change api for custom providers to support `openai-responses` instead of just `openai`, still supporting `openai` only.
-
-## 0.28.0
 - Add support for OpenAI Chat Completions API for broad third-party model support.
   - A new `openai-chat` custom provider `api` type was added to support any provider using the standard OpenAI `/v1/chat/completions` endpoint.
   - This enables easy integration with services like OpenRouter, Groq, DeepSeek, Together AI, and local LiteLLM instances.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Change api for custom providers to support `openai-responses` instead of just `openai`, still supporting `openai` only.
 
+## 0.28.0
+- Add support for OpenAI Chat Completions API for broad third-party model support.
+  - A new `openai-chat` custom provider `api` type was added to support any provider using the standard OpenAI `/v1/chat/completions` endpoint.
+  - This enables easy integration with services like OpenRouter, Groq, DeepSeek, Together AI, and local LiteLLM instances.
+
 ## 0.27.0
 
 - Add support for auto read `AGENT.md` from workspace root and global eca dir, considering as context for chat prompts.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,16 +203,6 @@ interface Config {
 When configuring custom providers, choose the appropriate API type:
 
 - **`openai-responses`**: OpenAI's new responses API endpoint (`/v1/responses`). Best for OpenAI models with enhanced features like reasoning and web search.
-- **`openai-chat`**: Standard OpenAI Chat Completions API (`/v1/chat/completions`). Use this for most third-party providers:
-  - OpenRouter
-  - DeepSeek
-  - Together AI
-  - Groq
-  - Local LiteLLM servers
-  - Any OpenAI-compatible provider
-- **`anthropic`**: Anthropic's native API for Claude models.
-
-Most third-party providers use the `openai-chat` API for compatibility with existing tools and libraries.
 
 ### Default values
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,10 +167,10 @@ interface Config {
     mcpServers: {[key: string]: {
         command: string;
         args?: string[];
-        disabled?: boolean; 
+        disabled?: boolean;
     }};
     customProviders: {[key: string]: {
-        api: 'openai' | 'anthropic';
+        api: 'openai-responses' | 'openai-chat' | 'anthropic';
         models: string[];
         defaultModel?: string;
         url?: string;
@@ -198,6 +198,22 @@ interface Config {
 }
 ```
 
+### Custom Provider API Types
+
+When configuring custom providers, choose the appropriate API type:
+
+- **`openai-responses`**: OpenAI's new responses API endpoint (`/v1/responses`). Best for OpenAI models with enhanced features like reasoning and web search.
+- **`openai-chat`**: Standard OpenAI Chat Completions API (`/v1/chat/completions`). Use this for most third-party providers:
+  - OpenRouter
+  - DeepSeek
+  - Together AI
+  - Groq
+  - Local LiteLLM servers
+  - Any OpenAI-compatible provider
+- **`anthropic`**: Anthropic's native API for Claude models.
+
+Most third-party providers use the `openai-chat` API for compatibility with existing tools and libraries.
+
 ### Default values
 
 ```javascript
@@ -210,7 +226,7 @@ interface Config {
   "rules" : [],
   "commands" : [],
   "nativeTools": {"filesystem": {"enabled": true},
-                  "shell": {"enabled": true, 
+                  "shell": {"enabled": true,
                             "excludeCommands": []}},
   "disabledTools": [],
   "toolCall": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,12 +198,6 @@ interface Config {
 }
 ```
 
-### Custom Provider API Types
-
-When configuring custom providers, choose the appropriate API type:
-
-- **`openai-responses`**: OpenAI's new responses API endpoint (`/v1/responses`). Best for OpenAI models with enhanced features like reasoning and web search.
-
 ### Default values
 
 ```javascript

--- a/docs/models.md
+++ b/docs/models.md
@@ -98,9 +98,25 @@ ECA allows you to configure custom LLM providers that follow API schemas similar
 - Custom company LLM endpoints
 - Additional cloud providers not natively supported
 
+### API Types for Custom Providers
+
+When configuring custom providers, choose the appropriate API type:
+
+- **`openai-responses`**: OpenAI's new responses API endpoint (`/v1/responses`). Best for OpenAI models with enhanced features like reasoning and web search.
+- **`openai-chat`**: Standard OpenAI Chat Completions API (`/v1/chat/completions`). Use this for most third-party providers:
+  - OpenRouter
+  - DeepSeek
+  - Together AI
+  - Groq
+  - Local LiteLLM servers
+  - Any OpenAI-compatible provider
+- **`anthropic`**: Anthropic's native API for Claude models.
+
+Most third-party providers use the `openai-chat` API for compatibility with existing tools and libraries.
+
 ### Setting up a custom provider
 
-It's possible to configure ECA to be aware of custom LLM providers if they follow a API schema similar to currently supported ones (openai, anthropic), example for a custom hosted litellm server:
+It's possible to configure ECA to be aware of custom LLM providers if they follow a API schema similar to currently supported ones (openai-responses, openai-chat or anthropic), example for a custom hosted litellm server:
 
 Example:
 
@@ -109,7 +125,7 @@ Example:
 {
   "customProviders": {
     "my-company": {
-       "api": "openai-responses",
+       "api": "openai-chat",
        "urlEnv": "MY_COMPANY_API_URL", // or "url"
        "keyEnv": "MY_COMPANY_API_KEY", // or "key"
        "models": ["gpt-5", "deepseek-r1"],
@@ -123,7 +139,7 @@ Example:
 
 | Option | Type | Description | Required |
 |--------|------|-------------|----------|
-| `api` | string | The API schema to use (`"openai-responses"` or `"anthropic"`) | Yes |
+| `api` | string | The API schema to use (`"openai-responses"`, `"openai-chat"`, or `"anthropic"`) | Yes |
 | `urlEnv` | string | Environment variable name containing the API URL | Yes* |
 | `url` | string | Direct API URL (use instead of `urlEnv`) | Yes* |
 | `keyEnv` | string | Environment variable name containing the API key | Yes* |
@@ -166,4 +182,40 @@ _* Either the `url` or `urlEnv` option is required, and either the `key` or `key
 }
 ```
 
-After configuring custom providers, the models will be available as `provider/model` (e.g., `litellm/gpt-5`, `enterprise/claude-3-opus-20240229`).
+### Example: OpenRouter
+
+[OpenRouter](https://openrouter.ai) provides access to many models through a unified API:
+
+```json
+{
+  "customProviders": {
+    "openrouter": {
+      "api": "openai-chat",
+      "url": "https://openrouter.ai/api/v1",
+      "keyEnv": "OPENROUTER_API_KEY",
+      "models": ["anthropic/claude-3.5-sonnet", "openai/gpt-4-turbo", "meta-llama/llama-3.1-405b"],
+      "defaultModel": "anthropic/claude-3.5-sonnet"
+    }
+  }
+}
+```
+
+### Example: DeepSeek
+
+[DeepSeek](https://deepseek.com) offers powerful reasoning and coding models:
+
+```json
+{
+  "customProviders": {
+    "deepseek": {
+      "api": "openai-chat",
+      "url": "https://api.deepseek.com",
+      "keyEnv": "DEEPSEEK_API_KEY",
+      "models": ["deepseek-chat", "deepseek-coder", "deepseek-reasoner"],
+      "defaultModel": "deepseek-chat"
+    }
+  }
+}
+```
+
+After configuring custom providers, the models will be available as `provider/model` (e.g., `openrouter/anthropic/claude-3.5-sonnet`, `deepseek/deepseek-chat`).

--- a/src/eca/llm_api.clj
+++ b/src/eca/llm_api.clj
@@ -6,7 +6,8 @@
    [eca.llm-providers.anthropic :as llm-providers.anthropic]
    [eca.llm-providers.ollama :as llm-providers.ollama]
    [eca.llm-providers.openai :as llm-providers.openai]
-   [eca.logger :as logger]))
+   [eca.logger :as logger]
+   [eca.llm-providers.openai-chat :as llm-providers.openai-chat]))
 
 (set! *warn-on-reflection* true)
 
@@ -182,6 +183,7 @@
                             ("openai-responses"
                              "openai") llm-providers.openai/completion!
                             "anthropic" llm-providers.anthropic/completion!
+                            "openai-chat" llm-providers.openai-chat/completion!
                             (on-error-wrapper {:message (format "Unknown custom model %s for provider %s" (:api provider-config) provider)}))
               url (or (:url provider-config) (config/get-env (:urlEnv provider-config)))
               key (or (:key provider-config) (config/get-env (:keyEnv provider-config)))

--- a/src/eca/llm_api.clj
+++ b/src/eca/llm_api.clj
@@ -6,8 +6,8 @@
    [eca.llm-providers.anthropic :as llm-providers.anthropic]
    [eca.llm-providers.ollama :as llm-providers.ollama]
    [eca.llm-providers.openai :as llm-providers.openai]
-   [eca.logger :as logger]
-   [eca.llm-providers.openai-chat :as llm-providers.openai-chat]))
+   [eca.llm-providers.openai-chat :as llm-providers.openai-chat]
+   [eca.logger :as logger]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/eca/llm_providers/openai_chat.clj
+++ b/src/eca/llm_providers/openai_chat.clj
@@ -166,32 +166,7 @@
 
    Handles the full conversation flow including tool calls, streaming responses,
    and message normalization. Supports both single and parallel tool execution.
-   Compatible with OpenRouter and other OpenAI-compatible providers.
-
-   Parameters:
-   - model: Model ID (e.g., 'gpt-4', 'gpt-3.5-turbo', 'o1-preview')
-   - user-messages: Current user input messages
-   - instructions: System-level instructions for the model
-   - temperature: Sampling temperature (default 1.0)
-   - api-key: API key for the provider
-   - api-url: Base URL for the provider's API
-   - max-output-tokens: Maximum tokens in response
-   - past-messages: Previous conversation history
-   - tools: Available tools for function calling
-   - extra-payload: Additional request parameters
-
-   Callbacks:
-   - on-message-received: Called for each streaming text chunk and finish events
-     Format: {:type :text :text \"chunk\"} or {:type :finish :finish-reason \"reason\"}
-   - on-error: Called for any errors during processing
-   - on-prepare-tool-call: Called as tool calls are being prepared/accumulated
-   - on-tools-called: Called when tools need execution, expects {:new-messages [...]}
-   - on-reason: Called for reasoning/thinking events (o1 models and compatible)
-     Format: {:status :started/:thinking/:finished :id \"uuid\" :text \"reasoning chunk\"}
-
-   The function handles the OpenAI streaming protocol, accumulates partial tool call
-   arguments across chunks, executes tools when complete, and manages the conversation
-   flow including recursive API calls for tool result processing."
+   Compatible with OpenRouter and other OpenAI-compatible providers."
   [{:keys [model user-messages instructions temperature api-key api-url max-output-tokens
            past-messages tools extra-payload]
     :or {temperature 1.0}}

--- a/src/eca/llm_providers/openai_chat.clj
+++ b/src/eca/llm_providers/openai_chat.clj
@@ -1,0 +1,303 @@
+(ns eca.llm-providers.openai-chat
+  (:require
+   [cheshire.core :as json]
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [eca.llm-util :as llm-util]
+   [eca.logger :as logger]
+   [hato.client :as http]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private logger-tag "[OPENAI-CHAT]")
+
+(def ^:private chat-completions-path "/chat/completions")
+
+(defn ^:private extract-content
+  "Extract text content from various message content formats.
+   Handles: strings (legacy eca), nested arrays from chat.clj, and fallback."
+  [content]
+  (cond
+    ;; Legacy/fallback: handles system messages, error strings, or unexpected simple text content
+    (string? content) (string/trim content)
+    (sequential? content) (->> content (map :text) (remove nil?) (string/join "\n"))
+    :else (str content)))
+
+(defn ^:private ->tools [tools]
+  (mapv (fn [tool]
+          {:type "function"
+           :function (select-keys tool [:name :description :parameters])})
+        tools))
+
+(defn ^:private base-request! [{:keys [rid body api-url api-key on-error on-response]}]
+  (let [url (str api-url chat-completions-path)]
+    (llm-util/log-request logger-tag rid url body)
+    (http/post
+     url
+     {:headers {"Authorization" (str "Bearer " api-key)
+                "Content-Type" "application/json"}
+      :body (json/generate-string body)
+      :throw-exceptions? false
+      :async? true
+      :as :stream}
+     (fn [{:keys [status body]}]
+       (try
+         (if (not= 200 status)
+           (let [body-str (slurp body)]
+             (logger/warn logger-tag "Unexpected response status: %s body: %s" status body-str)
+             (on-error {:message (format "OpenAI Chat response status: %s body: %s" status body-str)}))
+           (with-open [rdr (io/reader body)]
+             (doseq [[event data] (llm-util/event-data-seq rdr)]
+               (llm-util/log-response logger-tag rid event data)
+               (on-response event data))
+             (on-response "stream-end" {})))
+         (catch Exception e
+           (on-error {:exception e}))))
+     (fn [e]
+       (on-error {:exception e})))))
+
+(defn ^:private transform-message
+  "Transform a single ECA message to OpenAI format. Returns nil for unsupported roles."
+  [{:keys [role content] :as _msg}]
+  (case role
+    "tool_call"        {:type :tool-call  ; Special marker for accumulation
+                        :data {:id (:id content)
+                               :type "function"
+                               :function {:name (:name content)
+                                          :arguments (json/generate-string (:arguments content))}}}
+    "tool_call_output" {:role "tool"
+                        :tool_call_id (:id content)
+                        :content (llm-util/stringfy-tool-result content)}
+    "user"             {:role "user"
+                        :content (extract-content content)}
+    "assistant"        {:role "assistant"
+                        :content (extract-content content)}
+    "system"           {:role "system"
+                        :content (extract-content content)}
+    nil))
+
+(defn ^:private accumulate-tool-calls
+  "Handle tool call accumulation according to OpenAI API requirements.
+   Tool calls must be grouped into assistant messages."
+  [transformed-messages]
+  (let [{:keys [messages tool-calls]}
+        (reduce (fn [acc msg]
+                  (if (= :tool-call (:type msg))
+                    (update acc :tool-calls conj (:data msg))
+                    (let [acc-with-flushed
+                          (if (seq (:tool-calls acc))
+                            (-> acc
+                                (update :messages conj {:role "assistant"
+                                                        :tool_calls (:tool-calls acc)})
+                                (assoc :tool-calls []))
+                            acc)]
+                      (update acc-with-flushed :messages conj msg))))
+                {:messages [] :tool-calls []}
+                transformed-messages)]
+    ;; Flush any remaining tool calls
+    (if (seq tool-calls)
+      (conj messages {:role "assistant" :tool_calls tool-calls})
+      messages)))
+
+(defn ^:private valid-message?
+  "Check if a message should be included in the final output."
+  [{:keys [role content tool_calls] :as msg}]
+  (and msg
+       (or (= role "tool")           ; Never filter tool messages
+           (seq tool_calls)          ; Keep messages with tool calls
+           (and content              ; Keep messages with non-blank content
+                (not (string/blank? content))))))
+
+(defn ^:private normalize-messages
+  "Converts ECA message format to OpenAI API format (also used by compatible providers).
+
+   Key transformations:
+   - Flushes accumulated tool_calls into a single assistant message (OpenAI API requirement)
+   - Converts tool_call role to tool_calls array in assistant message
+   - Converts tool_call_output role to tool role with tool_call_id
+   - Extracts content from various message content formats
+
+   The OpenAI Chat Completions API requires that tool_calls must be present in an
+   'assistant' role message, not as separate messages. This function ensures compliance
+   with that requirement by accumulating tool calls and flushing them into assistant
+   messages when a non-tool_call message is encountered."
+  [past-messages]
+  (->> past-messages
+       (map transform-message)
+       (remove nil?)
+       accumulate-tool-calls
+       (filter valid-message?)))
+
+(defn ^:private execute-accumulated-tools!
+  [{:keys [tool-calls-atom instructions body api-url api-key on-tools-called on-error handle-response]}]
+  (let [all-accumulated (vals @tool-calls-atom)
+        completed-tools (->> all-accumulated
+                             (filter #(every? % [:id :name :arguments-text]))
+                             (map (fn [{:keys [arguments-text name] :as tool-call}]
+                                    (try
+                                      (assoc tool-call :arguments (json/parse-string arguments-text true))
+                                      (catch Exception e
+                                        (let [error-msg (format "Failed to parse JSON arguments for tool '%s': %s"
+                                                                name (ex-message e))]
+                                          (logger/warn logger-tag error-msg)
+                                          (assoc tool-call :arguments {} :parse-error error-msg)))))))
+        ;; Filter out tool calls with parse errors to prevent execution with invalid data
+        valid-tools (remove :parse-error completed-tools)]
+    (if (seq completed-tools)
+      ;; We have some completed tools (valid or with errors), so continue the conversation
+      (let [{:keys [new-messages]} (on-tools-called valid-tools)
+            new-messages-list (vec (concat
+                                    (when instructions [{:role "system" :content instructions}])
+                                    (normalize-messages new-messages)))]
+        (reset! tool-calls-atom {})
+        (let [new-rid (llm-util/gen-rid)]
+          (base-request!
+           {:rid new-rid
+            :body (assoc body :messages new-messages-list)
+            :api-url api-url
+            :api-key api-key
+            :on-error on-error
+            :on-response (fn [event data] (handle-response event data tool-calls-atom new-rid))})))
+      ;; No completed tools at all - let the streaming response provide the actual finish_reason
+      nil)))
+
+(defn completion!
+  "Primary entry point for OpenAI chat completions with streaming support.
+
+   Handles the full conversation flow including tool calls, streaming responses,
+   and message normalization. Supports both single and parallel tool execution.
+   Compatible with OpenRouter and other OpenAI-compatible providers.
+
+   Parameters:
+   - model: Model ID (e.g., 'gpt-4', 'gpt-3.5-turbo', 'o1-preview')
+   - user-messages: Current user input messages
+   - instructions: System-level instructions for the model
+   - temperature: Sampling temperature (default 1.0)
+   - api-key: API key for the provider
+   - api-url: Base URL for the provider's API
+   - max-output-tokens: Maximum tokens in response
+   - past-messages: Previous conversation history
+   - tools: Available tools for function calling
+   - extra-payload: Additional request parameters
+
+   Callbacks:
+   - on-message-received: Called for each streaming text chunk and finish events
+     Format: {:type :text :text \"chunk\"} or {:type :finish :finish-reason \"reason\"}
+   - on-error: Called for any errors during processing
+   - on-prepare-tool-call: Called as tool calls are being prepared/accumulated
+   - on-tools-called: Called when tools need execution, expects {:new-messages [...]}
+   - on-reason: Called for reasoning/thinking events (o1 models and compatible)
+     Format: {:status :started/:thinking/:finished :id \"uuid\" :text \"reasoning chunk\"}
+
+   The function handles the OpenAI streaming protocol, accumulates partial tool call
+   arguments across chunks, executes tools when complete, and manages the conversation
+   flow including recursive API calls for tool result processing."
+  [{:keys [model user-messages instructions temperature api-key api-url max-output-tokens
+           past-messages tools extra-payload]
+    :or {temperature 1.0}}
+   {:keys [on-message-received on-error on-prepare-tool-call on-tools-called on-reason]}]
+
+  (let [messages (vec (concat
+                       (when instructions [{:role "system" :content instructions}])
+                       (normalize-messages past-messages)
+                       (normalize-messages user-messages)))
+
+        body (merge {:model               model
+                     :messages            messages
+                     :temperature         temperature
+                     :stream              true
+                     :parallel_tool_calls true}
+                    (when max-output-tokens {:max_tokens max-output-tokens})
+                    (when (seq tools) {:tools (->tools tools)})
+                    extra-payload)
+
+        ;; Atom to accumulate tool call data from streaming chunks.
+        ;; OpenAI streams tool call arguments across multiple chunks, so we need to
+        ;; accumulate the partial JSON strings before parsing them. Keys are either
+        ;; index numbers for simple cases, or "index-id" composite keys for parallel
+        ;; tool calls that share the same index but have different IDs.
+        tool-calls* (atom {})
+
+        ;; Reasoning state tracking - generate new ID for each thinking block
+        current-reason-id* (atom nil)
+        reasoning-started* (atom false)
+
+        handle-response (fn handle-response [event data tool-calls-atom rid]
+                          (if (= event "stream-end")
+                            (execute-accumulated-tools!
+                             {:tool-calls-atom tool-calls-atom
+                              :instructions    instructions
+                              :body            body
+                              :api-url         api-url
+                              :api-key         api-key
+                              :on-tools-called on-tools-called
+                              :on-error        on-error
+                              :handle-response handle-response})
+                            (when (seq (:choices data))
+                              (doseq [choice (:choices data)]
+                                (let [delta         (:delta choice)
+                                      finish-reason (:finish_reason choice)]
+                                  ;; Process content if present
+                                  (when (:content delta)
+                                    (on-message-received {:type :text :text (:content delta)}))
+
+                                  ;; Process reasoning if present (o1 models and compatible providers)
+                                  (when-let [reasoning-text (:reasoning delta)]
+                                    (when on-reason
+                                      (when-not @reasoning-started*
+                                        ;; Generate new reason-id for each thinking block
+                                        (let [new-reason-id (str (random-uuid))]
+                                          (reset! current-reason-id* new-reason-id)
+                                          (reset! reasoning-started* true)
+                                          (on-reason {:status :started :id new-reason-id})))
+                                      (on-reason {:status :thinking
+                                                  :id     @current-reason-id*
+                                                  :text   reasoning-text})))
+
+                                  ;; Check if reasoning just stopped (was active, now nil, and we have content)
+                                  (when (and @reasoning-started*
+                                             (nil? (:reasoning delta))
+                                             (:content delta)
+                                             on-reason)
+                                    (on-reason {:status :finished :id @current-reason-id*})
+                                    (reset! reasoning-started* false))
+
+                                  ;; Process tool calls if present
+                                  (when (:tool_calls delta)
+                                    (doseq [tool-call (:tool_calls delta)]
+                                      (let [{:keys [index id function]}  tool-call
+                                            {name :name args :arguments} function
+                                            ;; Use RID as key to avoid collisions between API requests
+                                            tool-key                     (str rid "-" index)
+                                            ;; Create globally unique tool call ID for client
+                                            unique-id                    (when id (str rid "-" id))]
+                                        (when (and name unique-id)
+                                          (on-prepare-tool-call {:id unique-id :name name :arguments-text ""}))
+                                        (swap! tool-calls-atom update tool-key
+                                               (fn [existing]
+                                                 (cond-> (or existing {:index index})
+                                                   unique-id (assoc :id unique-id)
+                                                   name      (assoc :name name)
+                                                   args      (update :arguments-text (fnil str "") args))))
+                                        (when-let [updated-tool-call (get @tool-calls-atom tool-key)]
+                                          (when (and (:id updated-tool-call) (:name updated-tool-call)
+                                                     (not (string/blank? (:arguments-text updated-tool-call))))
+                                            (on-prepare-tool-call updated-tool-call))))))
+                                  ;; Process finish reason if present (but not tool_calls which is handled above)
+                                  (when finish-reason
+                                    ;; Handle reasoning completion
+                                    (when (and @reasoning-started* on-reason)
+                                      (on-reason {:status :finished :id @current-reason-id*})
+                                      (reset! reasoning-started* false))
+                                    ;; Handle regular finish
+                                    (when (not= finish-reason "tool_calls")
+                                      (on-message-received {:type :finish :finish-reason finish-reason}))))))))
+        rid (llm-util/gen-rid)]
+    (base-request!
+     {:rid         rid
+      :body        body
+      :api-url     api-url
+      :api-key     api-key
+      :tool-calls* tool-calls*
+      :on-error    on-error
+      :on-response (fn [event data] (handle-response event data tool-calls* rid))})))

--- a/test/eca/llm_providers/openai_chat_test.clj
+++ b/test/eca/llm_providers/openai_chat_test.clj
@@ -1,0 +1,148 @@
+(ns eca.llm-providers.openai-chat-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [eca.llm-providers.openai-chat :as llm-providers.openai-chat]
+   [matcher-combinators.test :refer [match?]]))
+
+(deftest normalize-messages-test
+  (testing "With tool_call history"
+    (is (match?
+         [{:role "user" :content "List the files"}
+          {:role "assistant" :content "I'll list the files for you"}
+          {:role "assistant"
+           :tool_calls [{:id "call-1"
+                         :type "function"
+                         :function {:name "list_files"
+                                    :arguments "{}"}}]}
+          {:role "tool"
+           :tool_call_id "call-1"
+           :content "file1.txt\nfile2.txt\n"}
+          {:role "assistant" :content "I found 2 files"}]
+         (#'llm-providers.openai-chat/normalize-messages
+          [{:role "user" :content "List the files"}
+           {:role "assistant" :content "I'll list the files for you"}
+           {:role "tool_call" :content {:id "call-1" :name "list_files" :arguments {}}}
+           {:role "tool_call_output" :content {:id "call-1"
+                                               :name "list_files"
+                                               :arguments {}
+                                               :output {:contents [{:type :text
+                                                                    :error false
+                                                                    :text "file1.txt\nfile2.txt"}]}}}
+           {:role "assistant" :content "I found 2 files"}]))))
+
+  (testing "Skips unsupported message types"
+    (is (match?
+         [{:role "user" :content "Hello"}
+          {:role "assistant" :content "Hi"}]
+         (remove nil?
+                 (#'llm-providers.openai-chat/normalize-messages
+                  [{:role "user" :content "Hello"}
+                   {:role "reason" :content {:text "Thinking..."}}
+                   {:role "assistant" :content "Hi"}]))))))
+
+(deftest extract-content-test
+  (testing "String input"
+    (is (= "Hello world"
+           (#'llm-providers.openai-chat/extract-content "  Hello world  "))))
+
+  (testing "Sequential messages with actual format"
+    (is (= "First message\nSecond message"
+           (#'llm-providers.openai-chat/extract-content
+            [{:text "First message"}
+             {:text "Second message"}]))))
+
+  (testing "Fallback to string conversion"
+    (is (= "{:some :other}"
+           (#'llm-providers.openai-chat/extract-content
+            {:some :other})))))
+
+(deftest ->tools-test
+  (testing "Converts ECA tools to OpenAI format"
+    (is (match?
+         [{:type "function"
+           :function {:name "get_weather"
+                      :description "Get the weather"
+                      :parameters {:type "object"
+                                   :properties {:location {:type "string"}}}}}]
+         (#'llm-providers.openai-chat/->tools
+          [{:name "get_weather"
+            :description "Get the weather"
+            :parameters {:type "object"
+                         :properties {:location {:type "string"}}}
+            :other-field "ignored"}]))))
+
+  (testing "Empty tools list"
+    (is (match?
+         []
+         (#'llm-providers.openai-chat/->tools [])))))
+
+(deftest transform-message-test
+  (testing "Tool call transformation"
+    (is (match?
+         {:type :tool-call
+          :data {:id "call-123"
+                 :type "function"
+                 :function {:name "get_weather"
+                            :arguments "{\"location\":\"NYC\"}"}}}
+         (#'llm-providers.openai-chat/transform-message
+          {:role "tool_call"
+           :content {:id "call-123"
+                     :name "get_weather"
+                     :arguments {:location "NYC"}}}))))
+
+  (testing "Tool call output transformation"
+    (is (match?
+         {:role "tool"
+          :tool_call_id "call-123"
+          :content "Sunny, 75°F\n"}
+         (#'llm-providers.openai-chat/transform-message
+          {:role "tool_call_output"
+           :content {:id "call-123"
+                     :output {:contents [{:type :text :text "Sunny, 75°F"}]}}}))))
+
+  (testing "Unsupported role returns nil"
+    (is (nil?
+         (#'llm-providers.openai-chat/transform-message
+          {:role "unsupported" :content "test"})))))
+
+(deftest accumulate-tool-calls-test
+  (testing "Multiple sequential tool calls get grouped"
+    (is (match?
+         [{:role "user" :content "What's the weather?"}
+          {:role "assistant"
+           :tool_calls [{:id "call-1" :function {:name "get_weather"}}
+                        {:id "call-2" :function {:name "get_location"}}]}
+          {:role "user" :content "Thanks"}]
+         (#'llm-providers.openai-chat/accumulate-tool-calls
+          [{:role "user" :content "What's the weather?"}
+           {:type :tool-call :data {:id "call-1" :function {:name "get_weather"}}}
+           {:type :tool-call :data {:id "call-2" :function {:name "get_location"}}}
+           {:role "user" :content "Thanks"}]))))
+
+  (testing "Tool calls at end of messages are flushed"
+    (is (match?
+         [{:role "user" :content "Test"}
+          {:role "assistant"
+           :tool_calls [{:id "call-1" :function {:name "test_tool"}}]}]
+         (#'llm-providers.openai-chat/accumulate-tool-calls
+          [{:role "user" :content "Test"}
+           {:type :tool-call :data {:id "call-1" :function {:name "test_tool"}}}])))))
+
+(deftest valid-message-test
+  (testing "Tool messages are always kept"
+    (is (#'llm-providers.openai-chat/valid-message?
+         {:role "tool" :tool_call_id "123" :content ""})))
+
+  (testing "Messages with tool calls are kept"
+    (is (#'llm-providers.openai-chat/valid-message?
+         {:role "assistant" :tool_calls [{:id "123"}]})))
+
+  (testing "Messages with blank content are filtered"
+    (is (not (#'llm-providers.openai-chat/valid-message?
+              {:role "user" :content "   "}))))
+
+  (testing "Messages with valid content are kept"
+    (is (#'llm-providers.openai-chat/valid-message?
+         {:role "user" :content "Hello world"}))))
+
+


### PR DESCRIPTION
Fixes #49 #18 

Adds support for the `openai-chat` API type for custom providers. This allows users to easily integrate any third-party service that is compatible with the standard OpenAI Chat Completions endpoint, such as OpenRouter, Groq, and DeepSeek.