### PR TITLE
Make reasoning parsing in openai-chat more robust

### DIFF
--- a/src/eca/llm_providers/openai_chat.clj
+++ b/src/eca/llm_providers/openai_chat.clj
@@ -217,7 +217,8 @@
                                     (on-message-received {:type :text :text (:content delta)}))
 
                                   ;; Process reasoning if present (o1 models and compatible providers)
-                                  (when-let [reasoning-text (:reasoning delta)]
+                                  (when-let [reasoning-text (or (:reasoning delta)
+                                                                (:reasoning_content delta))]
                                     (when on-reason
                                       (when-not @reasoning-started*
                                         ;; Generate new reason-id for each thinking block
@@ -232,6 +233,7 @@
                                   ;; Check if reasoning just stopped (was active, now nil, and we have content)
                                   (when (and @reasoning-started*
                                              (nil? (:reasoning delta))
+                                             (nil? (:reasoning_content delta))
                                              (:content delta)
                                              on-reason)
                                     (on-reason {:status :finished :id @current-reason-id*})


### PR DESCRIPTION
The previous implementation assumed the reasoning content would always be under the `:reasoning` key in the stream delta.

This change introduces a check for the `:reasoning_content` key as well. This directly enables support for the native reasoning stream from the DeepSeek API (e.g., for `deepseek-reasoner` models) and improves compatibility with other potential OpenAI-like providers that may use this key.