### PR TITLE
Rule file extension docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,7 @@ Prompts can use variables like `$ARGS`, `$ARG1`, `ARG2`, to replace in the promp
 ## Rules
 
 Rules are contexts that are passed to the LLM during a prompt and are useful to tune prompts or LLM behavior.
-Rules are text files (typically `.md` or `.mdc`, but any format works) with the following
+Rules are text files (typically `.md`, but any format works) with the following
 optional metadata:
 
 - `description`: a description used by LLM to decide whether to include this rule in context, absent means always include this rule.
@@ -129,7 +129,7 @@ There are 3 possible ways to configure rules following this order of priority:
 
     A `$XDG_CONFIG_HOME/eca/rules` or `~/.config/eca/rules` folder containing `.md` files with the rules.
 
-    `~/.config/eca/rules/talk_funny.mdc`
+    `~/.config/eca/rules/talk_funny.md`
     ```markdown
     --- 
     description: Use when responding anything

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,7 @@ Prompts can use variables like `$ARGS`, `$ARG1`, `ARG2`, to replace in the promp
 
     A `$XDG_CONFIG_HOME/eca/commands` or `~/.config/eca/commands` folder containing `.md` files with the custom command prompt.
 
-    `~/.config/eca/commands/check-performance.mdc`
+    `~/.config/eca/commands/check-performance.md`
     ```markdown
     Check for performance issues in $ARG1 and optimize if needed.
     ```
@@ -104,7 +104,8 @@ Prompts can use variables like `$ARGS`, `$ARG1`, `ARG2`, to replace in the promp
 ## Rules
 
 Rules are contexts that are passed to the LLM during a prompt and are useful to tune prompts or LLM behavior.
-Rules are Multi-Document context files (`.mdc`) and the following metadata is supported:
+Rules are text files (typically `.md` or `.mdc`, but any format works) with the following
+optional metadata:
 
 - `description`: a description used by LLM to decide whether to include this rule in context, absent means always include this rule.
 - `globs`: list of globs separated by `,`. When present the rule will be applied only when files mentioned matches those globs.
@@ -113,9 +114,9 @@ There are 3 possible ways to configure rules following this order of priority:
 
 === "Project file"
 
-    A `.eca/rules` folder from the workspace root containing `.mdc` files with the rules.
+    A `.eca/rules` folder from the workspace root containing `.md` files with the rules.
 
-    `.eca/rules/talk_funny.mdc`
+    `.eca/rules/talk_funny.md`
     ```markdown
     --- 
     description: Use when responding anything
@@ -126,7 +127,7 @@ There are 3 possible ways to configure rules following this order of priority:
 
 === "Global file"
 
-    A `$XDG_CONFIG_HOME/eca/rules` or `~/.config/eca/rules` folder containing `.mdc` files with the rules.
+    A `$XDG_CONFIG_HOME/eca/rules` or `~/.config/eca/rules` folder containing `.md` files with the rules.
 
     `~/.config/eca/rules/talk_funny.mdc`
     ```markdown
@@ -139,11 +140,11 @@ There are 3 possible ways to configure rules following this order of priority:
 
 === "Config"
 
-    Just add toyour config the `:rules` pointing to `.mdc` files that will be searched from the workspace root if not an absolute path:
+    Just add toyour config the `:rules` pointing to `.md` files that will be searched from the workspace root if not an absolute path:
 
     ```javascript
     {
-      "rules": [{"path": "my-rule.mdc"}]
+      "rules": [{"path": "my-rule.md"}]
     }
     ```
 


### PR DESCRIPTION
Addresses #63.

The code accepts rule files with any extension.
This PR updates the docs to reflect that.
It also removes mention of `.mdc` files as the preferred format.
