### PR TITLE
Fix hanging LSP diagnostics requests with configurable timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Fix reasoning titles in thoughts blocks for openai-responses.
+- Fix hanging LSP diagnostics requests
+- Add `lspTimeoutSeconds` to config
 
 ## 0.32.4
 
@@ -22,7 +24,7 @@
 
 ## 0.32.0
 
-- Refactor config for better UX and understanding: 
+- Refactor config for better UX and understanding:
   - Move `models` to inside `providers`.
   - Make `customProviders` compatible with `providers`. models need to be a map now, not a list.
 
@@ -32,7 +34,7 @@
 - Drop uneeded `ollama useTools` and `ollama think` configs.
 - Refactor configs for config providers unification.
   - `<provider>ApiKey` and `<providerApiUrl>` now live in `:providers "<provider>" :key`.
-  - Move `defaultModel` config from customProvider to root. 
+  - Move `defaultModel` config from customProvider to root.
 
 ## 0.30.0
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ There are multiples ways to configure ECA:
       }
     }
     ```
-  
+
 === "Local Config file"
 
     Convenient for users
@@ -31,7 +31,7 @@ There are multiples ways to configure ECA:
       }
     }
     ```
-    
+
 === "InitializationOptions"
 
     Convenient for editors
@@ -124,7 +124,7 @@ There are 3 possible ways to configure rules following this order of priority:
 
     `.eca/rules/talk_funny.md`
     ```markdown
-    --- 
+    ---
     description: Use when responding anything
     ---
 
@@ -137,7 +137,7 @@ There are 3 possible ways to configure rules following this order of priority:
 
     `~/.config/eca/rules/talk_funny.md`
     ```markdown
-    --- 
+    ---
     description: Use when responding anything
     ---
 
@@ -186,6 +186,7 @@ There are 3 possible ways to configure rules following this order of priority:
           manualApproval?: boolean | string[], // manual approve all tools or the specified tools
         };
         mcpTimeoutSeconds: number;
+        lspTimeoutSeconds: number;
         mcpServers: {[key: string]: {
             command: string;
             args?: string[];
@@ -232,6 +233,7 @@ There are 3 possible ways to configure rules following this order of priority:
         "manualApproval": null,
       },
       "mcpTimeoutSeconds" : 60,
+      "lspTimeoutSeconds" : 30,
       "mcpServers" : {},
       "chat" : {
         "defaultBehavior": "agent"

--- a/src/eca/config.clj
+++ b/src/eca/config.clj
@@ -56,6 +56,7 @@
                  :editor {:enabled true}}
    :disabledTools []
    :mcpTimeoutSeconds 60
+   :lspTimeoutSeconds 30
    :mcpServers {}
    :chat {:defaultBehavior "agent"
           :welcomeMessage "Welcome to ECA!\n\nType '/' for commands\n\n"}

--- a/test/eca/test_helper.clj
+++ b/test/eca/test_helper.clj
@@ -26,7 +26,7 @@
   (chat-content-received [_ data] (swap! messages* update :chat-content-received (fnil conj []) data))
   (tool-server-updated [_ data] (swap! messages* update :tool-server-update (fnil conj []) data))
   (showMessage [_ data] (swap! messages* update :show-message (fnil conj []) data))
-  (editor-diagnostics [_ _uri] (delay {:diagnostics @diagnostics*})))
+  (editor-diagnostics [_ _uri] (future {:diagnostics @diagnostics*})))
 
 (defn ^:private make-components []
   {:db* (atom db/initial-db)


### PR DESCRIPTION
Prevents ECA from hanging indefinitely when editor diagnostic requests don't respond by adding a configurable timeout mechanism.