### PR TITLE
Support tool call details for clojure-mcp

### DIFF
--- a/src/eca/diff.clj
+++ b/src/eca/diff.clj
@@ -55,3 +55,28 @@
       (->> (DiffUtils/generateUnifiedDiff file file original-lines patch 3)
            (drop 2) ;; removes file header
            unlines)})))
+
+(defn unified-diff-counts
+  "Given a unified diff string, return a map with counts of added and removed lines.
+
+  It ignores diff headers (---, +++), hunk markers (@@), and metadata lines starting with \\."
+  [diff-text]
+  (let [lines (string/split-lines diff-text)]
+    (reduce (fn [{:keys [added removed] :as acc} line]
+              (cond
+                (or (string/starts-with? line "---")
+                    (string/starts-with? line "+++")
+                    (string/starts-with? line "@@")
+                    (string/starts-with? line "\\")
+                    (string/blank? line))
+                acc
+
+                (string/starts-with? line "+")
+                (update acc :added inc)
+
+                (string/starts-with? line "-")
+                (update acc :removed inc)
+
+                :else acc))
+            {:added 0 :removed 0}
+            lines)))

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -188,7 +188,7 @@
                          (let [calls (doall
                                       (for [{:keys [id name arguments] :as tool-call} tool-calls]
                                         (let [approved?* (promise)
-                                              details (f.tools/get-tool-call-details name arguments)
+                                              details (f.tools/tool-call-details-before-invocation name arguments)
                                               summary (f.tools/tool-call-summary all-tools name arguments)
                                               origin (tool-name->origin name all-tools)
                                               manual-approval? (f.tools/manual-approval? name config)]
@@ -216,7 +216,8 @@
                                             (if @approved?*
                                               (do
                                                 (assert-chat-not-stopped! chat-ctx)
-                                                (let [result (f.tools/call-tool! name arguments @db* config messenger)]
+                                                (let [result (f.tools/call-tool! name arguments @db* config messenger)
+                                                      details (f.tools/tool-call-details-after-invocation name arguments details result)]
                                                   (add-to-history! {:role "tool_call" :content (assoc tool-call
                                                                                                       :details details
                                                                                                       :summary summary

--- a/src/eca/features/tools/mcp/clojure_mcp.clj
+++ b/src/eca/features/tools/mcp/clojure_mcp.clj
@@ -1,0 +1,35 @@
+(ns eca.features.tools.mcp.clojure-mcp
+  (:require [clojure.string :as string]
+            [eca.diff :as diff]
+            [eca.features.tools.util :as tools.util]))
+
+(defmethod tools.util/tool-call-details-after-invocation :clojure_edit [name arguments details result]
+  (tools.util/tool-call-details-after-invocation :file_edit arguments details result))
+
+(defmethod tools.util/tool-call-details-after-invocation :clojure_edit_replace_sexp [name arguments details result]
+  (tools.util/tool-call-details-after-invocation :file_edit arguments details result))
+
+(defmethod tools.util/tool-call-details-after-invocation :file_edit [name arguments details result]
+  (when-not (:error result)
+    (when-let [diff (some->> result :contents (filter #(= :text (:type %))) first :text)]
+      (let [{:keys [added removed]} (diff/unified-diff-counts diff)]
+        {:type :fileChange
+         :path (get arguments "file_path")
+         :linesAdded added
+         :linesRemoved removed
+         :diff diff}))))
+
+(defmethod tools.util/tool-call-details-after-invocation :file_write [name arguments details result]
+  (when-not (:error result)
+    (when-let [diff (some->> result :contents
+                             (filter #(= :text (:type %)))
+                             first :text
+                             (string/split-lines)
+                             (drop 2)
+                             (string/join "\n"))]
+      (let [{:keys [added removed]} (diff/unified-diff-counts diff)]
+        {:type :fileChange
+         :path (get arguments "file_path")
+         :linesAdded added
+         :linesRemoved removed
+         :diff diff}))))

--- a/src/eca/features/tools/util.clj
+++ b/src/eca/features/tools/util.clj
@@ -4,6 +4,20 @@
    [clojure.string :as string]
    [eca.shared :as shared]))
 
+(defmulti tool-call-details-before-invocation
+  "Return the tool call details before invoking the tool."
+  (fn [name arguments] (keyword name)))
+
+(defmethod tool-call-details-before-invocation :default [name arguments]
+  nil)
+
+(defmulti tool-call-details-after-invocation
+  "Return the tool call details after invoking the tool."
+  (fn [name arguments details result] (keyword name)))
+
+(defmethod tool-call-details-after-invocation :default [name arguments details result]
+  details)
+
 (defn single-text-content [text & [error]]
   {:error (boolean error)
    :contents [{:type :text

--- a/test/eca/diff_test.clj
+++ b/test/eca/diff_test.clj
@@ -39,10 +39,22 @@
       (is (some #{"-c"} lines) "diff should include -c line")))
 
   (testing "new file"
-    (let [revised  (string/join "\n" ["a" "b" "c" "d"])
+    (let [revised (string/join "\n" ["a" "b" "c" "d"])
           {:keys [added removed diff]} (diff/diff "" revised "file.txt")
           lines (split-diff-lines diff)]
       (is (= 4 added) "two lines added")
       (is (= 0 removed) "no lines removed")
       (is (some #{"+c"} lines) "diff should include +c line")
       (is (some #{"+d"} lines) "diff should include +d line"))))
+
+(deftest unified-diff-counts-test
+  (testing "counts added and removed lines from unified diff"
+    (let [example-diff (string/join "\n" ["--- original.txt"
+                                          "+++ revised.txt"
+                                          "@@ -1,1 +1,2 @@"
+                                          "-a"
+                                          "+b"
+                                          "+c"])
+          {:keys [added removed]} (diff/unified-diff-counts example-diff)]
+      (is (= 2 added) "one line added in the diff body")
+      (is (= 1 removed) "one line removed in the diff body"))))

--- a/test/eca/features/tools/mcp/clojure_mcp_test.clj
+++ b/test/eca/features/tools/mcp/clojure_mcp_test.clj
@@ -1,0 +1,80 @@
+(ns eca.features.tools.mcp.clojure-mcp-test
+  (:require
+   [clojure.string :as string]
+   [clojure.test :refer [deftest is testing]]
+   [eca.features.tools :as f.tools]
+   [matcher-combinators.test :refer [match?]]))
+
+(def ^:private example-diff
+  (string/join "\n" ["--- original.txt"
+                     "+++ revised.txt"
+                     "@@ -1,1 +1,2 @@"
+                     "-a"
+                     "+b"
+                     "+c"]))
+
+(deftest tool-call-details-after-invocation-clojure-mcp-clojure-edit-test
+  (testing "Tool call details for the Clojure MCP clojure_edit tool"
+    (is (match? {:type :fileChange
+                 :path "/home/alice/my-org/my-proj/project.clj"
+                 :linesAdded 2
+                 :linesRemoved 1
+                 :diff example-diff}
+                (f.tools/tool-call-details-after-invocation
+                 :clojure_edit
+                 {"file_path" "/home/alice/my-org/my-proj/project.clj"
+                  "form_identifier" "a"
+                  "form_type" "atom"
+                  "operation" "replace"
+                  "content" "b\nc"}
+                 nil
+                 {:error false :contents [{:type :text :text example-diff}]})))))
+
+(deftest tool-call-details-after-invocation-clojure-mcp-clojure-edit-replace-sexp-test
+  (testing "Tool call details for the Clojure MCP clojure_edit_replace_sexp tool"
+    (is (match? {:type :fileChange
+                 :path "/home/alice/my-org/my-proj/project.clj"
+                 :linesAdded 2
+                 :linesRemoved 1
+                 :diff example-diff}
+                (f.tools/tool-call-details-after-invocation
+                 :clojure_edit_replace_sexp
+                 {"file_path" "/home/alice/my-org/my-proj/project.clj"
+                  "match_form" "a"
+                  "new_form" "b\nc"
+                  "replace_all" false}
+                 nil
+                 {:error false :contents [{:type :text :text example-diff}]})))))
+
+(deftest tool-call-details-after-invocation-clojure-mcp-file-edit-test
+  (testing "Tool call details for the Clojure MCP file_edit tool"
+    (is (match? {:type :fileChange
+                 :path "/home/alice/my-org/my-proj/project.clj"
+                 :linesAdded 2
+                 :linesRemoved 1
+                 :diff example-diff}
+                (f.tools/tool-call-details-after-invocation
+                 :file_edit
+                 {"file_path" "/home/alice/my-org/my-proj/project.clj"
+                  "old_string" "a"
+                  "new_string" "b\nc"}
+                 nil
+                 {:error false :contents [{:type :text :text example-diff}]})))))
+
+(deftest tool-call-details-after-invocation-clojure-mcp-file-write-test
+  (testing "Tool call details for the Clojure MCP file_write tool"
+    (is (match? {:type :fileChange
+                 :path "/home/alice/my-org/my-proj/project.clj"
+                 :linesAdded 2
+                 :linesRemoved 1
+                 :diff example-diff}
+                (f.tools/tool-call-details-after-invocation
+                 :file_write
+                 {"file_path" "/home/alice/my-org/my-proj/project.clj"
+                  "content" "my-content"}
+                 nil
+                 {:error false
+                  :contents [{:type :text
+                              :text (string/join "\n"
+                                                 ["Clojure file updated: /home/alice/my-org/my-proj/project.clj"
+                                                  "Changes:" example-diff])}]})))))


### PR DESCRIPTION
Fixes #67 

This changes the `get-tool-call-details` into a multi method that can be specialized by tool name. It also adds a `get-tool-call-details-result`.

The `get-tool-call-details` method is called BEFORE the tool is called and the tool gets the chance to add information to inform the user that the tool is about to be called.

The `get-tool-call-details-result` method is called AFTER the tool is called and the tool gets the chance to add aditional information to the details from the `get-tool-call-details` and the actual result.

I tested this with the following prompts, and I do now see pretty diffs in the chat buffer.

```
create the test.clj file with the content "{:version "1.0.0"}"
bump the version in test.clj. you must use the file_edit MCP tool
bump the version in test.clj. you must use the file_write MCP tool
bump the version in test.clj. you must use the clojure_edit_replace_sexp MCP tool
bump the version in test.clj. you must use the clojure_edit MCP too
```

This PR needs the following change in Emacs (and possibly other clients):

https://github.com/editor-code-assistant/eca-emacs/pull/19

In my Emacs it looks like this:
<img width="1906" height="2236" alt="image" src="https://github.com/user-attachments/assets/18c86f9e-b8fe-41fc-9ecd-32dd6b7892fb" />
