### PR TITLE
Add missing parameters to toolCallRejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added missing parameters to `toolCallRejected` where possible.  PR #109
+
 ## 0.49.0
 
 - Add `totalTimeMs` to reason and toolCall content blocks.

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -86,7 +86,8 @@
    - promise init & delivery
    - logging/metrics
 
-   Note: all actions are run in the order specified.
+   Note: all actions are run in the order specified.  So, generally, the :send-* actions should be last.
+   Note: The :status is updated before any actions are run, so the actions have the latest :status.
 
    Note: all choices (i.e. conditionals) have to be made in code and result
    in different events sent to the state machine.
@@ -95,7 +96,7 @@
   {;; Note: transition-tool-call! treats no existing state as :initial state
    [:initial :tool-prepare]
    {:status :preparing
-    :actions [:send-toolCallPrepare :init-decision-reason]}
+    :actions [:init-tool-call-state :send-toolCallPrepare]}
 
    [:preparing :tool-prepare]
    {:status :preparing
@@ -103,7 +104,7 @@
 
    [:preparing :tool-run]
    {:status :check-approval
-    :actions [:init-approval-promise :send-toolCallRun]}
+    :actions [:init-arguments :init-approval-promise :send-toolCallRun]}
    ;; TODO: What happens if the promise is created, but no deref happens since the call is stopped?
 
    [:check-approval :approval-ask]
@@ -246,10 +247,21 @@
     (deliver (get-in @db* [:chats (:chat-id chat-ctx) :tool-calls tool-call-id :approved?*])
              true)
 
-    :init-decision-reason
-    (swap! db* assoc-in [:chats (:chat-id chat-ctx) :tool-calls tool-call-id :decision-reason]
-           {:reason {:code :none
-                     :text "No reason"}})
+    :init-tool-call-state
+    (swap! db* assoc-in [:chats (:chat-id chat-ctx) :tool-calls tool-call-id]
+           {;; :status is initialized by the state transition machinery
+            ;; :approval* is initialized by the :init-approval-promise action
+            ;; :arguments is initialized by the :init-arguments action
+            ;; :start-time is initialized by the :set-start-time action
+            :name (:name event-data)
+            :arguments (:arguments event-data)
+            :origin (:origin event-data)
+            :decision-reason {:code :none
+                              :text "No reason"}})
+
+    :init-arguments
+    (swap! db* assoc-in [:chats (:chat-id chat-ctx) :tool-calls tool-call-id]
+           :arguments (:arguments event-data))
 
     :set-decision-reason
     (swap! db* assoc-in [:chats (:chat-id chat-ctx) :tool-calls tool-call-id :decision-reason]

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -248,20 +248,20 @@
              true)
 
     :init-tool-call-state
-    (swap! db* assoc-in [:chats (:chat-id chat-ctx) :tool-calls tool-call-id]
-           {;; :status is initialized by the state transition machinery
-            ;; :approval* is initialized by the :init-approval-promise action
-            ;; :arguments is initialized by the :init-arguments action
-            ;; :start-time is initialized by the :set-start-time action
-            :name (:name event-data)
-            :arguments (:arguments event-data)
-            :origin (:origin event-data)
-            :decision-reason {:code :none
-                              :text "No reason"}})
+    (swap! db* update-in [:chats (:chat-id chat-ctx) :tool-calls tool-call-id] assoc
+           ;; :status is initialized by the state transition machinery
+           ;; :approval* is initialized by the :init-approval-promise action
+           ;; :arguments is initialized by the :init-arguments action
+           ;; :start-time is initialized by the :set-start-time action
+           :name (:name event-data)
+           :arguments (:arguments event-data)
+           :origin (:origin event-data)
+           :decision-reason {:code :none
+                             :text "No reason"})
 
     :init-arguments
-    (swap! db* assoc-in [:chats (:chat-id chat-ctx) :tool-calls tool-call-id]
-           :arguments (:arguments event-data))
+    (swap! db* assoc-in [:chats (:chat-id chat-ctx) :tool-calls tool-call-id :arguments]
+           (:arguments event-data))
 
     :set-decision-reason
     (swap! db* assoc-in [:chats (:chat-id chat-ctx) :tool-calls tool-call-id :decision-reason]

--- a/test/eca/features/chat_tool_call_state_test.clj
+++ b/test/eca/features/chat_tool_call_state_test.clj
@@ -121,7 +121,7 @@
       (let [result (#'f.chat/transition-tool-call! db* chat-ctx tool-call-id :tool-prepare event-data)]
 
         (is (match? {:status :preparing
-                     :actions [:send-toolCallPrepare :init-decision-reason]}
+                     :actions [:init-tool-call-state :send-toolCallPrepare]}
                     result)
             "Expected return value to show :preparing status and send toolCallPrepare action")
 
@@ -218,7 +218,7 @@
       (let [result (#'f.chat/transition-tool-call! db* chat-ctx tool-call-id :tool-run run-event-data)]
 
         (is (match? {:status :check-approval
-                     :actions [:init-approval-promise :send-toolCallRun]}
+                     :actions [:init-arguments :init-approval-promise :send-toolCallRun]}
                     result)
             "Expected next state to be :check-approval with actions of :init-approval-promise and :send-toolCallRun")
 
@@ -273,7 +273,7 @@
       ;; Step 2: :preparing -> :check-approval
       (let [result (#'f.chat/transition-tool-call! db* chat-ctx tool-call-id :tool-run run-event-data)]
         (is (match? {:status :check-approval
-                     :actions [:init-approval-promise :send-toolCallRun]}
+                     :actions [:init-arguments :init-approval-promise :send-toolCallRun]}
                     result)
             "Expected transition to :check-approval with init promise and send run actions")
 
@@ -517,6 +517,7 @@
                (#'f.chat/transition-tool-call! db* chat-ctx "tool-rejected" :stop-requested))
               "Expected exception as already rejected tool calls cannot be stopped"))))))
 
+;; TODO: This test and the previous test seem to be testing similar things.  Clean up.
 (deftest transition-tool-call-stop-transitions-test
   (testing "Stop transitions from various states"
     (h/reset-components!)


### PR DESCRIPTION
As we discussed after PR #104 was merged, `toolCallRejected` did not populate some of the values on `prompt-stop`.

It seems that the `argumentsText` in the `toolCallPrepare` message is the possibly incomplete JSON encoded string fragment that represents the arguments.
The only time we have the complete arguments is in the `:on-tools-called` callback.
So, if we get a `prompt-stop` after a `toolCallPrepare` but before a `toolCalled`, there is no way we have the arguments.
Therefore, in general, the clients will have to be changed to allow the `:arguments` in `toolCallRejected` to be null.
However, we can fill in the `:name` and `:origin` on `toolCallPrepare`, and fill in the `:arguments` on `toolCalled`.
- [ x] I added a entry in changelog under unreleased section.
