### PR TITLE
Feature/custom behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 - Added missing parameters to `toolCallRejected` where possible.  PR #109
+- Add custom behavior configuration support. #79
+  - Behaviors can now define `defaultModel`, `disabledTools`, `systemPromptFile`, and `toolCall` approval rules.
+  - Built-in `agent` and `plan` behaviors are pre-configured.
+  - Replace `systemPromptTemplateFile` with `systemPromptFile` for complete prompt files instead of templates.
+- Remove `nativeTools` configuration in favor of `toolCall` approval and `disabledTools`.
+  - Native tools are now always enabled by default, controlled via `disabledTools` and `toolCall` approval.
 
 ## 0.49.0
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,12 +342,6 @@ There are 3 possible ways to configure rules following this order of priority:
         rules?: [{path: string;}];
         commands?: [{path: string;}];
         systemPromptTemplateFile?: string;
-        nativeTools?: {
-            filesystem: {enabled: boolean};
-            shell: {enabled: boolean,
-                    excludeCommands: string[]};
-            editor: {enabled: boolean,};
-        };
         customTools?: {[key: string]: {
             description: string;
             command: string;
@@ -404,10 +398,6 @@ There are 3 possible ways to configure rules following this order of priority:
       "defaultModel": null, // let ECA decides the default model.
       "rules" : [],
       "commands" : [],
-      "nativeTools": {"filesystem": {"enabled": true},
-                      "shell": {"enabled": true,
-                                "excludeCommands": []},
-                       "editor": {"enabled": true}},
       "disabledTools": [],
       "toolCall": {
         "approval": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -341,7 +341,19 @@ There are 3 possible ways to configure rules following this order of priority:
         defaultModel?: string;
         rules?: [{path: string;}];
         commands?: [{path: string;}];
-        systemPromptTemplateFile?: string;
+        behavior?: {[key: string]: {
+            systemPromptFile?: string;
+            defaultModel?: string;
+            disabledTools?: string[];
+            toolCall?: {
+                approval?: {
+                    byDefault?: 'ask' | 'allow' | 'deny';
+                    allow?: {[key: string]: {argsMatchers?: {[key: string]: string[]}}};
+                    ask?: {[key: string]: {argsMatchers?: {[key: string]: string[]}}};
+                    deny?: {[key: string]: {argsMatchers?: {[key: string]: string[]}}};
+                };
+            };
+        }};
         customTools?: {[key: string]: {
             description: string;
             command: string;

--- a/docs/features.md
+++ b/docs/features.md
@@ -26,7 +26,7 @@ It supports both MCP server tools + ECA native tools.
 
 #### Native tools
 
-ECA support built-in tools to avoid user extra installation and configuration, these tools are always included on models requests that support tools and can be [disabled/configured via config](./configuration.md) `nativeTools`.
+ECA support built-in tools to avoid user extra installation and configuration, these tools are always included on models requests that support tools and can be [disabled via config](./configuration.md) `disabledTools`.
 
 ##### Filesystem
 
@@ -44,7 +44,7 @@ Provides access to filesystem under workspace root, listing, reading and writing
 
 Provides access to run shell commands, useful to run build tools, tests, and other common commands, supports exclude/include commands. 
 
-- `eca_shell_command`: run shell command. Supports configs to exclude commands via `:nativeTools :shell :excludeCommands`.
+- `eca_shell_command`: run shell command. Command exclusion can be configured using toolCall approval configuration with regex patterns.
 
 ##### Editor
 

--- a/integration-test/integration/initialize_test.clj
+++ b/integration-test/integration/initialize_test.clj
@@ -30,6 +30,7 @@
       (is (match?
            {:models models
             :chatDefaultModel "anthropic/claude-sonnet-4-20250514"
+            :chatBehaviors ["agent" "plan"]
             :chatDefaultBehavior "plan"
             :chatWelcomeMessage "Welcome to ECA!\n\nType '/' for commands\n\n"}
            (eca/request! (fixture/initialize-request
@@ -87,6 +88,7 @@
       (is (match?
            {:models models
             :chatDefaultModel "my-custom/bar-2"
+            :chatBehaviors ["agent" "plan"]
             :chatDefaultBehavior "agent"
             :chatWelcomeMessage "Welcome to ECA!\n\nType '/' for commands\n\n"}
            (eca/request! (fixture/initialize-request

--- a/integration-test/integration/initialize_test.clj
+++ b/integration-test/integration/initialize_test.clj
@@ -30,7 +30,6 @@
       (is (match?
            {:models models
             :chatDefaultModel "anthropic/claude-sonnet-4-20250514"
-            :chatBehaviors ["agent" "plan"]
             :chatDefaultBehavior "plan"
             :chatWelcomeMessage "Welcome to ECA!\n\nType '/' for commands\n\n"}
            (eca/request! (fixture/initialize-request
@@ -88,7 +87,6 @@
       (is (match?
            {:models models
             :chatDefaultModel "my-custom/bar-2"
-            :chatBehaviors ["agent" "plan"]
             :chatDefaultBehavior "agent"
             :chatWelcomeMessage "Welcome to ECA!\n\nType '/' for commands\n\n"}
            (eca/request! (fixture/initialize-request

--- a/resources/prompts/agent_behavior.md
+++ b/resources/prompts/agent_behavior.md
@@ -1,6 +1,24 @@
+You are ECA (Editor Code Assistant), an AI coding assistant that operates on an editor.
+
+You are pair programming with a USER to solve their coding task. Each time the USER sends a message, we may automatically attach some context information about their current state, such as passed contexts, rules defined by USER, project structure, and more. This information may or may not be relevant to the coding task, it is up for you to decide.
+
 You are an agent - please keep going until the user's query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved. Autonomously resolve the query to the best of your ability before coming back to the user.
 
 <edit_file_instructions>
 NEVER show the code edits or new files to the user - only call the proper tool. The system will apply and display the edits.
 For each file, give a short description of what needs to be edited, then use the available tool. You can use the tool multiple times in a response, and you can keep writing text after using a tool. Prefer multiple tool calls for specific code block changes instead of one big call changing the whole file or unnecessary parts of the code.
 </edit_file_instructions>
+
+<communication>
+The chat is markdown mode.
+When using markdown in assistant messages, use backticks to format file, directory, function, and class names.
+Pay attention to the language name after the code block backticks start, use the full language name like 'javascript' instead of 'js'.
+</communication>
+
+<tool_calling>
+You have tools at your disposal to solve the coding task. Follow these rules regarding tool calls:
+1. ALWAYS follow the tool call schema exactly as specified and make sure to provide all necessary parameters.
+2. If you need additional information that you can get via tool calls, prefer that over asking the user.
+3. If you are not sure about file content or codebase structure pertaining to the user's request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer.
+4. You have the capability to call multiple tools in a single response, batch your tool calls together for optimal performance.
+</tool_calling>

--- a/resources/prompts/plan_behavior.md
+++ b/resources/prompts/plan_behavior.md
@@ -1,3 +1,5 @@
+You are ECA (Editor Code Assistant), an AI coding assistant.
+
 ## Plan Mode
 
 You are in planning mode. Analyze the user's request and create a detailed implementation plan that can be executed later.
@@ -49,3 +51,18 @@ NEVER print codeblocks for file changes unless explicitly requested - use the ap
 
 ### Remember
 Plans can involve many activities beyond code changes. Use preview tool (eca_preview_file_change) when showing concrete file modifications, but embed them within your narrative explanation.
+
+
+<communication>
+The chat is markdown mode.
+When using markdown in assistant messages, use backticks to format file, directory, function, and class names.
+Pay attention to the language name after the code block backticks start, use the full language name like 'javascript' instead of 'js'.
+</communication>
+
+<tool_calling>
+You have tools at your disposal to solve the coding task. Follow these rules regarding tool calls:
+1. ALWAYS follow the tool call schema exactly as specified and make sure to provide all necessary parameters.
+2. If you need additional information that you can get via tool calls, prefer that over asking the user.
+3. If you are not sure about file content or codebase structure pertaining to the user's request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer.
+4. You have the capability to call multiple tools in a single response, batch your tool calls together for optimal performance.
+</tool_calling>

--- a/src/eca/config.clj
+++ b/src/eca/config.clj
@@ -58,6 +58,19 @@
                                           "claude-sonnet-4" {}}}
                "ollama" {:url "http://localhost:11434"
                          :urlEnv "OLLAMA_API_URL"}}
+   :behavior {"agent" {:systemPromptFile "prompts/agent_behavior.md"
+                       :disabledTools ["eca_preview_file_change"]}
+              "plan" {:systemPromptFile "prompts/plan_behavior.md"
+                      :disabledTools ["eca_edit_file" "eca_write_file" "eca_move_file"]
+                      :toolCall {:approval {:deny {"eca_shell_command"
+                                                   {:argsMatchers {"command" [".*>.*",
+                                                                              ".*\\|\\s*(tee|dd|xargs).*",
+                                                                              ".*\\b(sed|awk|perl)\\s+.*-i.*",
+                                                                              ".*\\b(rm|mv|cp|touch|mkdir)\\b.*",
+                                                                              ".*git\\s+(add|commit|push).*",
+                                                                              ".*npm\\s+install.*",
+                                                                              ".*-c\\s+[\"'].*open.*[\"']w[\"'].*",
+                                                                              ".*bash.*-c.*>.*"]}}}}}}}
    :defaultModel nil
    :rules []
    :commands []
@@ -193,7 +206,8 @@
   {:kebab-case
    [[:providers]]
    :stringfy
-   [[:providers]
+   [[:behavior]
+    [:providers]
     [:providers :ANY :models]
     [:toolCall :approval :allow]
     [:toolCall :approval :allow :ANY :argsMatchers]
@@ -203,7 +217,14 @@
     [:toolCall :approval :deny :ANY :argsMatchers]
     [:customTools]
     [:customTools :ANY :schema :properties]
-    [:mcpServers]]})
+    [:mcpServers]
+    ;; Behavior-specific toolCall
+    [:behavior :ANY :toolCall :approval :allow]
+    [:behavior :ANY :toolCall :approval :allow :ANY :argsMatchers]
+    [:behavior :ANY :toolCall :approval :ask]
+    [:behavior :ANY :toolCall :approval :ask :ANY :argsMatchers]
+    [:behavior :ANY :toolCall :approval :deny]
+    [:behavior :ANY :toolCall :approval :deny :ANY :argsMatchers]]})
 
 (defn all [db]
   (let [initialization-config @initialization-config*

--- a/src/eca/config.clj
+++ b/src/eca/config.clj
@@ -61,10 +61,6 @@
    :defaultModel nil
    :rules []
    :commands []
-   :nativeTools {:filesystem {:enabled true}
-                 :shell {:enabled true
-                         :excludeCommands []}
-                 :editor {:enabled true}}
    :disabledTools []
    :toolCall {:approval {:byDefault "ask"
                          :allow {"eca_preview_file_change" {}

--- a/src/eca/config.clj
+++ b/src/eca/config.clj
@@ -92,6 +92,18 @@
            :repoMap {:maxTotalEntries 800
                      :maxEntriesPerDir 50}}})
 
+(def ^:private fallback-behavior "agent")
+
+(defn validate-behavior-name
+  "Validates if a behavior exists in config. Returns the behavior if valid,
+   or the fallback behavior if not."
+  [behavior config]
+  (if (contains? (:behavior config) behavior)
+    behavior
+    (do (logger/warn logger-tag (format "Unknown behavior '%s' specified, falling back to '%s'"
+                                        behavior fallback-behavior))
+        fallback-behavior)))
+
 (defn get-env [env] (System/getenv env))
 (defn get-property [property] (System/getProperty property))
 

--- a/src/eca/db.clj
+++ b/src/eca/db.clj
@@ -24,7 +24,6 @@
    :providers-config-hash nil
    :last-config-notified {}
    :stopping false
-   :chat-behaviors ["agent" "plan"]
    :models {}
    :mcp-clients {}
 

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -3,6 +3,7 @@
    [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.string :as string]
+   [eca.config :as config]
    [eca.db :as db]
    [eca.features.commands :as f.commands]
    [eca.features.context :as f.context]
@@ -659,7 +660,7 @@
         raw-behavior (or behavior
                          (-> config :chat :defaultBehavior) ;; legacy
                          (-> config :defaultBehavior))
-        selected-behavior (config/validate-behavior raw-behavior config)
+        selected-behavior (config/validate-behavior-name raw-behavior config)
         behavior-config (get-in config [:behavior selected-behavior])
         ;; Simple model selection without behavior switching logic
         full-model (or model

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -656,9 +656,10 @@
                       (swap! db* assoc-in [:chats new-id] {:id new-id})
                       new-id))
         db @db*
-        selected-behavior (or behavior
-                              (-> config :chat :defaultBehavior) ;; legacy
-                              (-> config :defaultBehavior))
+        raw-behavior (or behavior
+                         (-> config :chat :defaultBehavior) ;; legacy
+                         (-> config :defaultBehavior))
+        selected-behavior (config/validate-behavior raw-behavior config)
         behavior-config (get-in config [:behavior selected-behavior])
         ;; Simple model selection without behavior switching logic
         full-model (or model

--- a/src/eca/features/prompt.clj
+++ b/src/eca/features/prompt.clj
@@ -33,19 +33,17 @@
         ;; Use systemPromptFile from behavior config, or fall back to built-in
         prompt-file (or (:systemPromptFile behavior-config)
                        ;; For built-in behaviors without explicit config
-                       (when (#{"agent" "plan"} behavior)
-                         (str "prompts/" behavior "_behavior.md")))]
+                        (when (#{"agent" "plan"} behavior)
+                          (str "prompts/" behavior "_behavior.md")))]
     (cond
       ;; Custom behavior with absolute path
       (and prompt-file (string/starts-with? prompt-file "/"))
       (slurp prompt-file)
-      
+
       ;; Built-in or resource path
       prompt-file
-      (load-builtin-prompt (if (string/starts-with? prompt-file "prompts/")
-                            (subs prompt-file 8) ; Remove "prompts/" prefix
-                            prompt-file))
-      
+      (load-builtin-prompt (some-> prompt-file (string/replace-first #"prompts/" "")))
+
       ;; Fallback for unknown behavior
       :else
       (load-builtin-prompt "agent_behavior.md"))))

--- a/src/eca/features/prompt.clj
+++ b/src/eca/features/prompt.clj
@@ -12,14 +12,11 @@
 
 (def ^:private logger-tag "[PROMPT]")
 
-(defn ^:private base-prompt-template* [] (slurp (io/resource "prompts/eca_base.md")))
-(def ^:private base-prompt-template (memoize base-prompt-template*))
+;; Built-in behavior prompts are now complete files, not templates
+(defn ^:private load-builtin-prompt* [filename]
+  (slurp (io/resource (str "prompts/" filename))))
 
-(defn ^:private plan-behavior* [] (slurp (io/resource "prompts/plan_behavior.md")))
-(def ^:private plan-behavior (memoize plan-behavior*))
-
-(defn ^:private agent-behavior* [] (slurp (io/resource "prompts/agent_behavior.md")))
-(def ^:private agent-behavior (memoize agent-behavior*))
+(def ^:private load-builtin-prompt (memoize load-builtin-prompt*))
 
 (defn ^:private init-prompt-template* [] (slurp (io/resource "prompts/init.md")))
 (def ^:private init-prompt-template (memoize init-prompt-template*))
@@ -32,13 +29,26 @@
    vars))
 
 (defn ^:private eca-prompt [behavior config]
-  (let [prompt (or (some-> (:systemPromptTemplateFile config) slurp)
-                   (base-prompt-template))]
-    (replace-vars
-     prompt
-     {:behavior (case behavior
-                  "plan" (plan-behavior)
-                  "agent" (agent-behavior))})))
+  (let [behavior-config (get-in config [:behavior behavior])
+        ;; Use systemPromptFile from behavior config, or fall back to built-in
+        prompt-file (or (:systemPromptFile behavior-config)
+                       ;; For built-in behaviors without explicit config
+                       (when (#{"agent" "plan"} behavior)
+                         (str "prompts/" behavior "_behavior.md")))]
+    (cond
+      ;; Custom behavior with absolute path
+      (and prompt-file (string/starts-with? prompt-file "/"))
+      (slurp prompt-file)
+      
+      ;; Built-in or resource path
+      prompt-file
+      (load-builtin-prompt (if (string/starts-with? prompt-file "prompts/")
+                            (subs prompt-file 8) ; Remove "prompts/" prefix
+                            prompt-file))
+      
+      ;; Fallback for unknown behavior
+      :else
+      (load-builtin-prompt "agent_behavior.md"))))
 
 (defn build-instructions [refined-contexts rules repo-map* behavior config]
   (multi-str

--- a/src/eca/features/tools.clj
+++ b/src/eca/features/tools.clj
@@ -20,6 +20,22 @@
 
 (def ^:private logger-tag "[TOOLS]")
 
+(defn ^:private get-disabled-tools
+  "Returns a set of disabled tools, merging global and behavior-specific."
+  [config behavior]
+  (set (concat (get config :disabledTools [])
+               (if behavior
+                 (get-in config [:behavior behavior :disabledTools] [])
+                 []))))
+
+(defn make-tool-status-fn
+  "Returns a function that marks tools as disabled based on config and behavior.
+   If behavior is nil, only uses global disabledTools."
+  [config behavior]
+  (let [disabled-tools (get-disabled-tools config behavior)]
+    (fn [tool]
+      (assoc-some tool :disabled (contains? disabled-tools (:name tool))))))
+
 (defn ^:private native-definitions [db config]
   (into
    {}
@@ -29,22 +45,19 @@
                     (update :description #(-> %
                                               (string/replace #"\$workspaceRoots" (constantly (tools.util/workspace-roots-strs db))))))]))
    (merge {}
-          (when (get-in config [:nativeTools :filesystem :enabled])
-            f.tools.filesystem/definitions)
-          (when (get-in config [:nativeTools :shell :enabled])
-            f.tools.shell/definitions)
-          (when (get-in config [:nativeTools :editor :enabled])
-            f.tools.editor/definitions)
+          f.tools.filesystem/definitions
+          f.tools.shell/definitions
+          f.tools.editor/definitions
           (f.tools.custom/definitions config))))
 
-(defn ^:private native-tools [db config]
+(defn native-tools [db config]
   (mapv #(assoc % :server "eca") (vals (native-definitions db config))))
 
 (defn all-tools
   "Returns all available tools, including both native ECA tools
    (like filesystem and shell tools) and tools provided by MCP servers."
   [behavior db config]
-  (let [disabled-tools (set (get-in config [:disabledTools] []))]
+  (let [disabled-tools (get-disabled-tools config behavior)]
     (filterv
      (fn [tool]
        (and (not (contains? disabled-tools (:name tool)))
@@ -76,27 +89,24 @@
                      :text (str "Error calling tool: " (.getMessage e))}]}))))
 
 (defn init-servers! [db* messenger config]
-  (let [disabled-tools (set (get-in config [:disabledTools] []))
-        with-tool-status (fn [tool]
-                           (assoc-some tool :disabled (contains? disabled-tools (:name tool))))]
+  (let [default-behavior (get config :defaultBehavior)
+        tool-status-fn (make-tool-status-fn config default-behavior)]
     (messenger/tool-server-updated messenger {:type :native
                                               :name "ECA"
                                               :status "running"
                                               :tools (->> (native-tools @db* config)
                                                           (mapv #(select-keys % [:name :description :parameters]))
-                                                          (mapv with-tool-status))})
+                                                          (mapv tool-status-fn))})
     (f.mcp/initialize-servers-async!
      {:on-server-updated (fn [server]
                            (messenger/tool-server-updated messenger (-> server
                                                                         (assoc :type :mcp)
-                                                                        (update :tools #(mapv with-tool-status %)))))}
+                                                                        (update :tools #(mapv tool-status-fn %)))))}
      db*
      config)))
 
 (defn stop-server! [name db* messenger config]
-  (let [disabled-tools (set (get-in config [:disabledTools] []))
-        with-tool-status (fn [tool]
-                           (assoc-some tool :disabled (contains? disabled-tools (:name tool))))]
+  (let [tool-status-fn (make-tool-status-fn config nil)]
     (f.mcp/stop-server!
      name
      db*
@@ -104,12 +114,10 @@
      {:on-server-updated (fn [server]
                            (messenger/tool-server-updated messenger (-> server
                                                                         (assoc :type :mcp)
-                                                                        (update :tools #(mapv with-tool-status %)))))})))
+                                                                        (update :tools #(mapv tool-status-fn %)))))})))
 
 (defn start-server! [name db* messenger config]
-  (let [disabled-tools (set (get-in config [:disabledTools] []))
-        with-tool-status (fn [tool]
-                           (assoc-some tool :disabled (contains? disabled-tools (:name tool))))]
+  (let [tool-status-fn (make-tool-status-fn config nil)]
     (f.mcp/start-server!
      name
      db*
@@ -117,7 +125,7 @@
      {:on-server-updated (fn [server]
                            (messenger/tool-server-updated messenger (-> server
                                                                         (assoc :type :mcp)
-                                                                        (update :tools #(mapv with-tool-status %)))))})))
+                                                                        (update :tools #(mapv tool-status-fn %)))))})))
 
 (defn legacy-manual-approval? [config tool-name]
   (let [manual-approval? (get-in config [:toolCall :manualApproval] nil)]
@@ -157,38 +165,41 @@
 
 (defn approval
   "Return the approval keyword for the specific tool call: ask, allow or deny."
-  [all-tools tool-call-name args db config]
-  (let [{:keys [server require-approval-fn]} (first (filter #(= tool-call-name (:name %))
-                                                            all-tools))
-        {:keys [allow ask deny byDefault]} (get-in config [:toolCall :approval])]
-    (cond
-      (and require-approval-fn (require-approval-fn args {:db db}))
-      :ask
+  ([all-tools tool-call-name args db config]
+   (approval all-tools tool-call-name args db config nil))
+  ([all-tools tool-call-name args db config behavior]
+   (let [{:keys [server require-approval-fn]} (first (filter #(= tool-call-name (:name %))
+                                                             all-tools))
+         {:keys [allow ask deny byDefault]}   (merge (get-in config [:toolCall :approval])
+                                                     (get-in config [:behavior behavior :toolCall :approval]))]
+     (cond
+       (and require-approval-fn (require-approval-fn args {:db db}))
+       :ask
 
-      (some #(approval-matches? % server tool-call-name args) deny)
-      :deny
+       (some #(approval-matches? % server tool-call-name args) deny)
+       :deny
 
-      (some #(approval-matches? % server tool-call-name args) ask)
-      :ask
+       (some #(approval-matches? % server tool-call-name args) ask)
+       :ask
 
-      (some #(approval-matches? % server tool-call-name args) allow)
-      :allow
+       (some #(approval-matches? % server tool-call-name args) allow)
+       :allow
 
-      (legacy-manual-approval? config tool-call-name)
-      :ask
+       (legacy-manual-approval? config tool-call-name)
+       :ask
 
-      (= "ask" byDefault)
-      :ask
+       (= "ask" byDefault)
+       :ask
 
-      (= "allow" byDefault)
-      :allow
+       (= "allow" byDefault)
+       :allow
 
-      (= "deny" byDefault)
-      :deny
+       (= "deny" byDefault)
+       :deny
 
-      ;; Probably a config error, default to ask
-      :else
-      :ask)))
+       ;; Probably a config error, default to ask
+       :else
+       :ask))))
 
 (defn tool-call-summary [all-tools name args]
   (when-let [summary-fn (:summary-fn (first (filter #(= name (:name %))

--- a/src/eca/features/tools/filesystem.clj
+++ b/src/eca/features/tools/filesystem.clj
@@ -309,8 +309,6 @@
                                          :description "The complete content to write to the file"}}
                  :required ["path" "content"]}
     :handler #'write-file
-    ;; TODO - add behaviors to config and define disabled tools there!
-    :enabled-fn #(not= "plan" (:behavior %))
     :summary-fn #'write-file-summary}
    "eca_edit_file"
    {:description (tools.util/read-tool-description "eca_edit_file")
@@ -325,7 +323,6 @@
                                                   :description "Whether to replace all occurences of the file or just the first one (default)"}}
                   :required ["path" "original_content" "new_content"]}
     :handler #'edit-file
-    :enabled-fn #(not= "plan" (:behavior %))
     :summary-fn (constantly "Editting file")}
    "eca_preview_file_change"
    {:description (tools.util/read-tool-description "eca_preview_file_change")
@@ -340,7 +337,6 @@
                                                  :description "Whether to preview replacing all occurrences or just the first one (default)"}}
                  :required ["path" "original_content" "new_content"]}
     :handler #'preview-file-change
-    :enabled-fn #(= "plan" (:behavior %))
     :summary-fn (constantly "Previewing change")}
    "eca_move_file"
    {:description (tools.util/read-tool-description "eca_move_file")
@@ -351,7 +347,6 @@
                                               :description "The new absolute file path to move to."}}
                   :required ["source" "destination"]}
     :handler #'move-file
-    :enabled-fn #(not= "plan" (:behavior %))
     :summary-fn (constantly "Moving file")}
    "eca_grep"
    {:description (tools.util/read-tool-description "eca_grep")

--- a/src/eca/features/tools/shell.clj
+++ b/src/eca/features/tools/shell.clj
@@ -11,44 +11,12 @@
 
 (def ^:private logger-tag "[TOOLS-SHELL]")
 
-;; Plan mode command restrictions
-;; TODO - We might see that this is not needed and prompt handles it.
-;;        If we don't get 'Command bocked in plan model' error for some time, let's remove it.
-;;        Maybe we should use allowed patterns only, especially for user's custom behaviors.
-(def ^:private plan-safe-commands-default
-  #{"git" "ls" "find" "grep" "rg" "ag" "cat" "head" "tail"
-    "pwd" "which" "file" "stat" "tree" "date" "whoami"
-    "env" "echo" "wc" "du" "df"})
-
-(def ^:private plan-forbidden-patterns-default
-  [#">"                              ; output redirection
-   #"\|\s*(tee|dd|xargs)"            ; dangerous pipes
-   #"\b(sed|awk|perl)\s+.*-i"       ; in-place editing
-   #"\b(rm|mv|cp|touch|mkdir)\b"    ; file operations
-   #"git\s+(add|commit|push)"       ; git mutations
-   #"npm\s+install"                 ; package installs
-   #"-c\s+[\"'].*open.*[\"']w[\"']" ; programmatic writes
-   #"bash.*-c.*>"])                 ; nested shell redirects
-
-(defn ^:private safe-for-plan-mode? [command-string]
-  (let [cmd (-> command-string (string/split #"\s+") first)]
-    (and (contains? plan-safe-commands-default cmd)
-         (not (some #(re-find % command-string) plan-forbidden-patterns-default)))))
-
-(defn ^:private shell-command [arguments {:keys [db config behavior]}]
+(defn ^:private shell-command [arguments {:keys [db config]}]
   (let [command-args (get arguments "command")
         command (first (string/split command-args #"\s+"))
-        user-work-dir (get arguments "working_directory")
-        plan-mode? (= "plan" behavior)]
+        user-work-dir (get arguments "working_directory")]
     (or (tools.util/invalid-arguments arguments [["working_directory" #(or (nil? %)
-                                                                           (fs/exists? %)) "working directory $working_directory does not exist"]
-                                                 ["commmand" (constantly (not (contains? exclude-cmds command)))
-                                                  (format "Command '%s' is excluded by configuration" command-args)]])
-        ;; Check plan mode restrictions
-        (when (and plan-mode? (not (safe-for-plan-mode? command-args)))
-          {:error true
-           :contents [{:type :text
-                       :text "Command blocked in plan mode. Only read-only analysis commands are allowed."}]})
+                                                                           (fs/exists? %)) "working directory $working_directory does not exist"]])
         (let [work-dir (or (some-> user-work-dir fs/canonicalize str)
                            (some-> (:workspace-folders db)
                                    first

--- a/src/eca/features/tools/shell.clj
+++ b/src/eca/features/tools/shell.clj
@@ -39,7 +39,6 @@
   (let [command-args (get arguments "command")
         command (first (string/split command-args #"\s+"))
         user-work-dir (get arguments "working_directory")
-        exclude-cmds (-> config :nativeTools :shell :excludeCommands set)
         plan-mode? (= "plan" behavior)]
     (or (tools.util/invalid-arguments arguments [["working_directory" #(or (nil? %)
                                                                            (fs/exists? %)) "working directory $working_directory does not exist"]

--- a/src/eca/handlers.clj
+++ b/src/eca/handlers.clj
@@ -32,6 +32,7 @@
      (models/sync-models! db* config (fn [_]))
      (let [db @db*]
        {:models (sort (keys (:models db)))
+        :chat-behaviors (distinct (keys (:behavior config)))
         :chat-default-model (f.chat/default-model db config)
         :chat-default-behavior (config/validate-behavior-name
                                 (or (:defaultBehavior (:chat config)) ;;legacy

--- a/src/eca/handlers.clj
+++ b/src/eca/handlers.clj
@@ -33,9 +33,10 @@
      (let [db @db*]
        {:models (sort (keys (:models db)))
         :chat-default-model (f.chat/default-model db config)
-        :chat-behaviors (:chat-behaviors db)
-        :chat-default-behavior (or (:defaultBehavior (:chat config)) ;;legacy
-                                   (:defaultBehavior config))
+        :chat-default-behavior (config/validate-behavior-name
+                                (or (:defaultBehavior (:chat config)) ;;legacy
+                                    (:defaultBehavior config))
+                                config)
         :chat-welcome-message (or (:welcomeMessage (:chat config)) ;;legacy
                                   (:welcomeMessage config))}))))
 
@@ -49,18 +50,20 @@
                                                                           (config/notify-fields-changed-only!
                                                                            {:chat
                                                                             {:models (sort (keys models))
-                                                                             :behaviors (->> (keys (:behavior config))
-                                                                                             (into (:chat-behaviors db))
-                                                                                             distinct)
+                                                                             :behaviors (distinct (keys (:behavior config)))
                                                                              :select-model (f.chat/default-model db config)
-                                                                             :select-behavior (or (:defaultBehavior (:chat config)) ;;legacy
-                                                                                                  (:defaultBehavior config))
+                                                                             :select-behavior (config/validate-behavior-name
+                                                                                               (or (:defaultBehavior (:chat config)) ;;legacy
+                                                                                                   (:defaultBehavior config))
+                                                                                               config)
                                                                              :welcome-message (or (:welcomeMessage (:chat config)) ;;legacy
                                                                                                   (:welcomeMessage config))
                                                                              ;; Deprecated, remove after changing emacs, vscode and intellij.
                                                                              :default-model (f.chat/default-model db config)
-                                                                             :default-behavior (or (:defaultBehavior (:chat config)) ;;legacy
-                                                                                                   (:defaultBehavior config))}}
+                                                                             :default-behavior (config/validate-behavior-name
+                                                                                                (or (:defaultBehavior (:chat config)) ;;legacy
+                                                                                                    (:defaultBehavior config))
+                                                                                                config)}}
                                                                            messenger
                                                                            db*)))))))]
     (swap! db* assoc-in [:config-updated-fns :sync-models] #(sync-models-and-notify! %))
@@ -169,7 +172,8 @@
   "Switches model to the one defined in custom-behavior or to the default-one
    and updates tool status for the new behavior"
   [{:keys [db* messenger config]} {:keys [behavior]}]
-  (let [behavior-config (get-in config [:behavior behavior])
-        tool-status-fn (f.tools/make-tool-status-fn config behavior)]
+  (let [validated-behavior (config/validate-behavior-name behavior config)
+        behavior-config (get-in config [:behavior validated-behavior])
+        tool-status-fn (f.tools/make-tool-status-fn config validated-behavior)]
     (update-behavior-model! behavior-config config messenger db*)
     (update-tool-servers! tool-status-fn db* messenger config)))

--- a/test/eca/features/tools/shell_test.clj
+++ b/test/eca/features/tools/shell_test.clj
@@ -99,7 +99,7 @@
       "date"
       "env")))
 
-(deftest plan-mode-restrictions-test
+(deftest plan-mode-approval-restrictions-test
   (let [all-tools [{:name "eca_shell_command" :server "eca"}]
         config config/initial-config]
     

--- a/test/eca/features/tools/shell_test.clj
+++ b/test/eca/features/tools/shell_test.clj
@@ -3,6 +3,8 @@
    [babashka.fs :as fs]
    [babashka.process :as p]
    [clojure.test :refer [deftest is testing are]]
+   [eca.config :as config]
+   [eca.features.tools :as f.tools]
    [eca.features.tools.shell :as f.tools.shell]
    [eca.test-helper :as h]
    [matcher-combinators.test :refer [match?]]))
@@ -95,56 +97,58 @@
       "head -10 file.txt"
       "pwd"
       "date"
-      "env"))
+      "env")))
 
-  (testing "dangerous commands blocked in plan mode"
-    (are [command] (match?
-                    {:error true
-                     :contents [{:type :text
-                                 :text "Command blocked in plan mode. Only read-only analysis commands are allowed."}]}
-                    ((get-in f.tools.shell/definitions ["eca_shell_command" :handler])
-                     {"command" command}
-                     {:db {:workspace-folders [{:uri (h/file-uri "file:///project/foo") :name "foo"}]}
-                      :behavior "plan"}))
-      "echo 'test' > file.txt"
-      "cat file.txt > output.txt"
-      "ls >> log.txt"
-      "rm file.txt"
-      "mv old.txt new.txt"
-      "cp file1.txt file2.txt"
-      "touch newfile.txt"
-      "mkdir newdir"
-      "sed -i 's/old/new/' file.txt"
-      "git add ."
-      "git commit -m 'test'"
-      "npm install package"
-      "python -c \"open('file.txt','w').write('test')\""
-      "bash -c 'echo test > file.txt'"))
-
-  (testing "commands not in whitelist blocked in plan mode"
-    (are [command] (match?
-                    {:error true
-                     :contents [{:type :text
-                                 :text "Command blocked in plan mode. Only read-only analysis commands are allowed."}]}
-                    ((get-in f.tools.shell/definitions ["eca_shell_command" :handler])
-                     {"command" command}
-                     {:db {:workspace-folders [{:uri (h/file-uri "file:///project/foo") :name "foo"}]}
-                      :behavior "plan"}))
-      "python --version"  ; not in whitelist
-      "node script.js"     ; not in whitelist
-      "clojure -M:test"))   ; not in whitelist
-
-  (testing "same commands work fine in agent mode"
-    (are [command] (match?
-                    {:error false
-                     :contents [{:type :text
-                                 :text "Some output"}]}
-                    (with-redefs [fs/exists? (constantly true)
-                                  p/shell (constantly {:exit 0 :out "Some output"})]
-                      ((get-in f.tools.shell/definitions ["eca_shell_command" :handler])
-                       {"command" command}
-                       {:db {:workspace-folders [{:uri (h/file-uri "file:///project/foo") :name "foo"}]}
-                        :behavior "agent"})))
-      "echo 'test' > file.txt"
-      "rm file.txt"
-      "python --version")))
+(deftest plan-mode-restrictions-test
+  (let [all-tools [{:name "eca_shell_command" :server "eca"}]
+        config config/initial-config]
+    
+    (testing "dangerous commands blocked in plan mode via approval"
+      (are [command] (= :deny 
+                       (f.tools/approval all-tools "eca_shell_command" 
+                                       {"command" command} {} config "plan"))
+        "echo 'test' > file.txt"
+        "cat file.txt > output.txt"
+        "ls >> log.txt"
+        "rm file.txt"
+        "mv old.txt new.txt"
+        "cp file1.txt file2.txt"
+        "touch newfile.txt"
+        "mkdir newdir"
+        "sed -i 's/old/new/' file.txt"
+        "git add ."
+        "git commit -m 'test'"
+        "npm install package"
+        "python -c \"open('file.txt','w').write('test')\""
+        "bash -c 'echo test > file.txt'"))
+    
+    (testing "non-dangerous commands default to ask in plan mode"
+      (are [command] (= :ask
+                       (f.tools/approval all-tools "eca_shell_command"
+                                       {"command" command} {} config "plan"))
+        "python --version"  ; not matching dangerous patterns, defaults to ask
+        "node script.js"     ; not matching dangerous patterns, defaults to ask
+        "clojure -M:test"))  ; not matching dangerous patterns, defaults to ask
+    
+    (testing "safe commands not denied in plan mode"
+      (are [command] (not= :deny
+                          (f.tools/approval all-tools "eca_shell_command"
+                                          {"command" command} {} config "plan"))
+        "git status"
+        "ls -la"
+        "find . -name '*.clj'"
+        "grep 'test' file.txt"
+        "cat file.txt"
+        "head -10 file.txt"
+        "pwd"
+        "date"
+        "env"))
+    
+    (testing "same commands work fine in agent mode (not denied)"
+      (are [command] (not= :deny
+                          (f.tools/approval all-tools "eca_shell_command"
+                                          {"command" command} {} config "agent"))
+        "echo 'test' > file.txt"
+        "rm file.txt"
+        "git add ."
+        "python --version"))))

--- a/test/eca/features/tools/shell_test.clj
+++ b/test/eca/features/tools/shell_test.clj
@@ -51,29 +51,7 @@
             {"command" "ls -lh"
              "working_directory" (h/file-path "/project/foo/src")}
             {:db {:workspace-folders [{:uri (h/file-uri "file:///project/foo") :name "foo"}]}})))))
-  (testing "command does not fails if not in excluded config"
-    (is (match?
-         {:error false
-          :contents [{:type :text
-                      :text "Some text"}]}
-         (with-redefs [fs/exists? (constantly true)
-                       p/shell (constantly {:exit 0 :out "Some text" :err "Other text"})]
-           ((get-in f.tools.shell/definitions ["eca_shell_command" :handler])
-            {"command" "rm -r /project/foo/src"}
-            {:db {:workspace-folders [{:uri (h/file-uri "file:///project/foo") :name "foo"}]}
-             :config {:nativeTools {:shell {:enabled true
-                                            :excludeCommands ["ls" "cd"]}}}})))))
-  (testing "command fails if in excluded config"
-    (is (match?
-         {:error true
-          :contents [{:type :text
-                      :text "Command 'rm -r /project/foo/src' is excluded by configuration"}]}
-         (with-redefs [fs/exists? (constantly true)]
-           ((get-in f.tools.shell/definitions ["eca_shell_command" :handler])
-            {"command" "rm -r /project/foo/src"}
-            {:db {:workspace-folders [{:uri (h/file-uri "file:///project/foo") :name "foo"}]}
-             :config {:nativeTools {:shell {:enabled true
-                                            :excludeCommands ["ls" "rm"]}}}}))))))
+)
 
 (deftest shell-require-approval-fn-test
   (let [approval-fn (get-in f.tools.shell/definitions ["eca_shell_command" :require-approval-fn])

--- a/test/eca/features/tools_test.clj
+++ b/test/eca/features/tools_test.clj
@@ -35,18 +35,18 @@
     (is (match?
          (m/embeds [(m/mismatch {:name "eca_directory_tree"})])
          (f.tools/all-tools "agent" {} {:disabledTools ["eca_directory_tree"]}))))
-  #_(testing "Plan mode includes preview tool but excludes mutating tools"
-      (let [plan-tools (f.tools/all-tools "plan" {} {:nativeTools {:filesystem {:enabled true}
-                                                                   :shell {:enabled true}}})
-            tool-names (set (map :name plan-tools))]
+  (testing "Plan mode includes preview tool but excludes mutating tools"
+    (let [plan-config {:behavior {"plan" {:disabledTools ["eca_edit_file" "eca_write_file" "eca_move_file"]}}}
+          plan-tools (f.tools/all-tools "plan" {} plan-config)
+          tool-names (set (map :name plan-tools))]
       ;; Verify that preview tool is included
-        (is (contains? tool-names "eca_preview_file_change"))
+      (is (contains? tool-names "eca_preview_file_change"))
       ;; Verify that shell command is now allowed in plan mode (with restrictions in prompt)
-        (is (contains? tool-names "eca_shell_command"))
+      (is (contains? tool-names "eca_shell_command"))
       ;; Verify that mutating tools are excluded
-        (is (not (contains? tool-names "eca_edit_file")))
-        (is (not (contains? tool-names "eca_write_file")))
-        (is (not (contains? tool-names "eca_move_file")))))
+      (is (not (contains? tool-names "eca_edit_file")))
+      (is (not (contains? tool-names "eca_write_file")))
+      (is (not (contains? tool-names "eca_move_file")))))
   (testing "Do not include plan edit tool if agent behavior"
     (is (match?
          (m/embeds [(m/mismatch {:name "eca_preview_file_change"})

--- a/test/eca/features/tools_test.clj
+++ b/test/eca/features/tools_test.clj
@@ -1,6 +1,7 @@
 (ns eca.features.tools-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [eca.config :as config]
    [eca.features.tools :as f.tools]
    [eca.features.tools.filesystem :as f.tools.filesystem]
    [eca.test-helper :as h]
@@ -63,6 +64,30 @@
            (f.tools/all-tools "agent" {:workspace-folders [{:name "foo" :uri (h/file-uri "file:///path/to/project/foo")}]}
                               {}))))))
 
+(deftest get-disabled-tools-test
+  (testing "merges global and behavior-specific disabled tools"
+    (let [config {:disabledTools ["global_tool"]
+                  :behavior {"plan" {:disabledTools ["plan_tool"]}
+                             "custom" {:disabledTools ["custom_tool"]}}}]
+      (is (= #{"global_tool" "plan_tool"}
+             (#'f.tools/get-disabled-tools config "plan")))
+      (is (= #{"global_tool" "custom_tool"}
+             (#'f.tools/get-disabled-tools config "custom")))))
+  (testing "behavior with no disabled tools"
+    (let [config {:disabledTools ["global_tool"]
+                  :behavior {"empty" {}}}]
+      (is (= #{"global_tool"}
+             (#'f.tools/get-disabled-tools config "empty")))))
+  (testing "nil behavior returns only global disabled tools"
+    (let [config {:disabledTools ["global_tool"]
+                  :behavior {"plan" {:disabledTools ["plan_tool"]}}}]
+      (is (= #{"global_tool"}
+             (#'f.tools/get-disabled-tools config nil)))))
+  (testing "no global disabled tools"
+    (let [config {:behavior {"plan" {:disabledTools ["plan_tool"]}}}]
+      (is (= #{"plan_tool"}
+             (#'f.tools/get-disabled-tools config "plan"))))))
+
 (deftest manual-approval?-test
   (let [all-tools [{:name "eca_read" :server "eca"}
                    {:name "eca_write" :server "eca"}
@@ -71,46 +96,93 @@
                    {:name "request" :server "web"}
                    {:name "download" :server "web"}]]
     (testing "tool has require-approval-fn which returns true"
-      (is (= :ask (f.tools/approval all-tools "eca_shell" {} {} {}))))
+      (is (= :ask (f.tools/approval all-tools "eca_shell" {} {} {} nil))))
     (testing "tool has require-approval-fn which returns false we ignore it"
-      (is (= :ask (f.tools/approval all-tools "eca_plan" {} {} {}))))
+      (is (= :ask (f.tools/approval all-tools "eca_plan" {} {} {} nil))))
     (testing "if legacy-manual-approval present, considers it"
-      (is (= :ask (f.tools/approval all-tools "request" {} {} {:toolCall {:manualApproval true}}))))
+      (is (= :ask (f.tools/approval all-tools "request" {} {} {:toolCall {:manualApproval true}} nil))))
     (testing "if approval config is provided"
       (testing "when matches allow config"
-        (is (= :allow (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:allow {"web__request" {}}}}})))
-        (is (= :allow (f.tools/approval all-tools "eca_read" {} {} {:toolCall {:approval {:allow {"eca_read" {}}}}})))
-        (is (= :allow (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:allow {"web" {}}}}}))))
+        (is (= :allow (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:allow {"web__request" {}}}}} nil)))
+        (is (= :allow (f.tools/approval all-tools "eca_read" {} {} {:toolCall {:approval {:allow {"eca_read" {}}}}} nil)))
+        (is (= :allow (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:allow {"web" {}}}}} nil))))
       (testing "when matches ask config"
-        (is (= :ask (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:ask {"web__request" {}}}}})))
-        (is (= :ask (f.tools/approval all-tools "eca_read" {} {} {:toolCall {:approval {:ask {"eca_read" {}}}}})))
-        (is (= :ask (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:ask {"web" {}}}}}))))
+        (is (= :ask (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:ask {"web__request" {}}}}} nil)))
+        (is (= :ask (f.tools/approval all-tools "eca_read" {} {} {:toolCall {:approval {:ask {"eca_read" {}}}}} nil)))
+        (is (= :ask (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:ask {"web" {}}}}} nil))))
       (testing "when matches deny config"
-        (is (= :deny (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:deny {"web__request" {}}}}})))
-        (is (= :deny (f.tools/approval all-tools "eca_read" {} {} {:toolCall {:approval {:deny {"eca_read" {}}}}})))
-        (is (= :deny (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:deny {"web" {}}}}}))))
+        (is (= :deny (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:deny {"web__request" {}}}}} nil)))
+        (is (= :deny (f.tools/approval all-tools "eca_read" {} {} {:toolCall {:approval {:deny {"eca_read" {}}}}} nil)))
+        (is (= :deny (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:deny {"web" {}}}}} nil))))
       (testing "when contains argsMatchers"
         (testing "has arg but not matches"
           (is (= :ask (f.tools/approval all-tools "request" {"url" "http://bla.com"} {}
-                                        {:toolCall {:approval {:allow {"web__request" {:argsMatchers {"url" [".*foo.*"]}}}}}}))))
+                                        {:toolCall {:approval {:allow {"web__request" {:argsMatchers {"url" [".*foo.*"]}}}}}} nil))))
         (testing "has arg and matches for allow"
           (is (= :allow (f.tools/approval all-tools "request" {"url" "http://foo.com"} {}
-                                          {:toolCall {:approval {:allow {"web__request" {:argsMatchers {"url" [".*foo.*"]}}}}}})))
+                                          {:toolCall {:approval {:allow {"web__request" {:argsMatchers {"url" [".*foo.*"]}}}}}} nil)))
           (is (= :allow (f.tools/approval all-tools "request" {"url" "foobar"} {}
-                                          {:toolCall {:approval {:allow {"web__request" {:argsMatchers {"url" ["foo.*"]}}}}}}))))
+                                          {:toolCall {:approval {:allow {"web__request" {:argsMatchers {"url" ["foo.*"]}}}}}} nil))))
         (testing "has arg and matches for deny"
           (is (= :deny (f.tools/approval all-tools "request" {"url" "http://foo.com"} {}
-                                         {:toolCall {:approval {:deny {"web__request" {:argsMatchers {"url" [".*foo.*"]}}}}}})))
+                                         {:toolCall {:approval {:deny {"web__request" {:argsMatchers {"url" [".*foo.*"]}}}}}} nil)))
           (is (= :deny (f.tools/approval all-tools "request" {"url" "foobar"} {}
-                                         {:toolCall {:approval {:deny {"web__request" {:argsMatchers {"url" ["foo.*"]}}}}}}))))
+                                         {:toolCall {:approval {:deny {"web__request" {:argsMatchers {"url" ["foo.*"]}}}}}} nil))))
         (testing "has not that arg"
           (is (= :ask (f.tools/approval all-tools "request" {"crazy-url" "http://foo.com"} {}
-                                        {:toolCall {:approval {:allow {"web__request" {:argsMatchers {"url" [".*foo.*"]}}}}}}))))))
+                                        {:toolCall {:approval {:allow {"web__request" {:argsMatchers {"url" [".*foo.*"]}}}}}} nil))))))
     (testing "if no approval config matches"
       (testing "checks byDefault"
         (testing "when 'ask', return true"
-          (is (= :ask (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:byDefault "ask"}}}))))
+          (is (= :ask (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:byDefault "ask"}}} nil))))
         (testing "when 'allow', return false"
-          (is (= :allow (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:byDefault "allow"}}})))))
+          (is (= :allow (f.tools/approval all-tools "request" {} {} {:toolCall {:approval {:byDefault "allow"}}} nil)))))
       (testing "fallback to manual approval"
-        (is (= :ask (f.tools/approval all-tools "request" {} {} {})))))))
+        (is (= :ask (f.tools/approval all-tools "request" {} {} {} nil)))))))
+
+(deftest behavior-specific-approval-test
+  (let [all-tools [{:name "eca_shell_command" :server "eca"}
+                   {:name "eca_read_file" :server "eca"}]]
+    (testing "behavior-specific approval overrides global rules"
+      (let [config {:toolCall {:approval {:byDefault "allow"}}
+                    :behavior {"plan" {:toolCall {:approval {:deny {"eca_shell_command" {:argsMatchers {"command" [".*rm.*"]}}}
+                                                              :byDefault "ask"}}}}}]
+        ;; Global config would allow shell commands (no behavior specified)
+        (is (= :allow (f.tools/approval all-tools "eca_shell_command" {"command" "ls -la"} {} config nil)))
+        ;; But plan behavior denies rm commands
+        (is (= :deny (f.tools/approval all-tools "eca_shell_command" {"command" "rm file.txt"} {} config "plan")))
+        ;; Plan behavior allows other shell commands with ask (behavior byDefault)
+        (is (= :ask (f.tools/approval all-tools "eca_shell_command" {"command" "ls -la"} {} config "plan")))))
+    (testing "behavior without toolCall approval uses global rules"
+      (let [config {:toolCall {:approval {:allow {"eca_read_file" {}}}}
+                    :behavior {"custom" {}}}]
+        (is (= :allow (f.tools/approval all-tools "eca_read_file" {} {} config "custom")))))
+    (testing "plan behavior shell restrictions work as configured"
+      (let [config {:behavior {"plan" {:toolCall {:approval {:deny {"eca_shell_command" {:argsMatchers {"command" [".*>.*" ".*rm.*"]}}}}}}}}]
+        (is (= :deny (f.tools/approval all-tools "eca_shell_command" {"command" "cat file.txt > output.txt"} {} config "plan")))
+        (is (= :deny (f.tools/approval all-tools "eca_shell_command" {"command" "rm -rf folder"} {} config "plan")))
+        ;; Safe commands should use byDefault (ask)
+        (is (= :ask (f.tools/approval all-tools "eca_shell_command" {"command" "ls -la"} {} config "plan")))))
+    (testing "agent behavior does NOT have plan restrictions"
+      (let [config {:behavior {"plan" {:toolCall {:approval {:deny {"eca_shell_command" {:argsMatchers {"command" [".*>.*" ".*rm.*"]}}}}}}}}]
+        ;; Same dangerous commands that are denied in plan mode should be allowed in agent mode
+        (is (= :ask (f.tools/approval all-tools "eca_shell_command" {"command" "rm -rf folder"} {} config "agent")))
+        (is (= :ask (f.tools/approval all-tools "eca_shell_command" {"command" "cat file.txt > output.txt"} {} config "agent")))
+        ;; No behavior specified (nil) should also not have plan restrictions
+        (is (= :ask (f.tools/approval all-tools "eca_shell_command" {"command" "rm file.txt"} {} config nil)))))
+    (testing "regex patterns match dangerous commands correctly" 
+      (let [config config/initial-config]
+        ;; Test output redirection patterns
+        (is (= :deny (f.tools/approval all-tools "eca_shell_command" {"command" "echo test > file.txt"} {} config "plan")))
+        (is (= :deny (f.tools/approval all-tools "eca_shell_command" {"command" "ls >> log.txt"} {} config "plan")))
+        ;; Test pipe to dangerous commands
+        (is (= :deny (f.tools/approval all-tools "eca_shell_command" {"command" "echo test | tee file.txt"} {} config "plan")))
+        (is (= :deny (f.tools/approval all-tools "eca_shell_command" {"command" "find . | xargs rm"} {} config "plan")))
+        ;; Test file operations
+        (is (= :deny (f.tools/approval all-tools "eca_shell_command" {"command" "rm -rf folder"} {} config "plan")))
+        (is (= :deny (f.tools/approval all-tools "eca_shell_command" {"command" "touch newfile.txt"} {} config "plan")))
+        ;; Test git operations
+        (is (= :deny (f.tools/approval all-tools "eca_shell_command" {"command" "git add ."} {} config "plan")))
+        ;; Test safe commands that should NOT be denied
+        (is (= :ask (f.tools/approval all-tools "eca_shell_command" {"command" "ls -la"} {} config "plan")))
+        (is (= :ask (f.tools/approval all-tools "eca_shell_command" {"command" "git status"} {} config "plan")))))))

--- a/test/eca/features/tools_test.clj
+++ b/test/eca/features/tools_test.clj
@@ -30,28 +30,28 @@
                      :description string?
                      :parameters some?
                      :origin :native}])
-         (f.tools/all-tools "agent" {} {:nativeTools {:filesystem {:enabled true}}}))))
+         (f.tools/all-tools "agent" {} {}))))
   (testing "Do not include disabled native tools"
     (is (match?
          (m/embeds [(m/mismatch {:name "eca_directory_tree"})])
-         (f.tools/all-tools "agent" {} {:nativeTools {:filesystem {:enabled false}}}))))
-  (testing "Plan mode includes preview tool but excludes mutating tools"
-    (let [plan-tools (f.tools/all-tools "plan" {} {:nativeTools {:filesystem {:enabled true}
-                                                                 :shell {:enabled true}}})
-          tool-names (set (map :name plan-tools))]
+         (f.tools/all-tools "agent" {} {:disabledTools ["eca_directory_tree"]}))))
+  #_(testing "Plan mode includes preview tool but excludes mutating tools"
+      (let [plan-tools (f.tools/all-tools "plan" {} {:nativeTools {:filesystem {:enabled true}
+                                                                   :shell {:enabled true}}})
+            tool-names (set (map :name plan-tools))]
       ;; Verify that preview tool is included
-      (is (contains? tool-names "eca_preview_file_change"))
+        (is (contains? tool-names "eca_preview_file_change"))
       ;; Verify that shell command is now allowed in plan mode (with restrictions in prompt)
-      (is (contains? tool-names "eca_shell_command"))
+        (is (contains? tool-names "eca_shell_command"))
       ;; Verify that mutating tools are excluded
-      (is (not (contains? tool-names "eca_edit_file")))
-      (is (not (contains? tool-names "eca_write_file")))
-      (is (not (contains? tool-names "eca_move_file")))))
+        (is (not (contains? tool-names "eca_edit_file")))
+        (is (not (contains? tool-names "eca_write_file")))
+        (is (not (contains? tool-names "eca_move_file")))))
   (testing "Do not include plan edit tool if agent behavior"
     (is (match?
          (m/embeds [(m/mismatch {:name "eca_preview_file_change"})
                     {:name "eca_edit_file"}])
-         (f.tools/all-tools "agent" {} {:nativeTools {:filesystem {:enabled true}}}))))
+         (f.tools/all-tools "agent" {} {}))))
   (testing "Replace special vars description"
     (is (match?
          (m/embeds [{:name "eca_directory_tree"
@@ -61,7 +61,7 @@
          (with-redefs [f.tools.filesystem/definitions {"eca_directory_tree" {:description "Only in $workspaceRoots"
                                                                              :parameters {}}}]
            (f.tools/all-tools "agent" {:workspace-folders [{:name "foo" :uri (h/file-uri "file:///path/to/project/foo")}]}
-                              {:nativeTools {:filesystem {:enabled true}}}))))))
+                              {}))))))
 
 (deftest manual-approval?-test
   (let [all-tools [{:name "eca_read" :server "eca"}

--- a/test/eca/handlers_test.clj
+++ b/test/eca/handlers_test.clj
@@ -5,7 +5,19 @@
    [eca.db :as db]
    [eca.handlers :as handlers]
    [eca.models :as models]
+   [eca.features.tools :as f.tools]
+   [eca.messenger :as messenger]
    [matcher-combinators.test :refer [match?]]))
+
+(defrecord MockMessenger [calls-atom]
+  messenger/IMessenger
+  (config-updated [this params]
+    (swap! calls-atom conj [:config-updated params]))
+  (tool-server-updated [this params]
+    (swap! calls-atom conj [:tool-server-updated params]))
+  (chat-content-received [this data] nil)
+  (showMessage [this msg] nil)
+  (editor-diagnostics [this uri] nil))
 
 (deftest initialize-test
   (testing "initializationOptions config is merged properly with default init config"
@@ -24,3 +36,71 @@
                                                      "gpt-5-mini" {}}
                                             :url string?}}}
              (config/all @db*)))))))
+
+(deftest chat-selected-behavior-changed-test
+  (testing "Switching to behavior with defaultModel updates model"
+    (let [db* (atom {:last-config-notified {} :mcp-clients {}})
+          messenger-calls (atom [])
+          config {:behavior {"custom" {:defaultModel "gpt-4.1"}}}
+          mock-messenger (->MockMessenger messenger-calls)]
+      (handlers/chat-selected-behavior-changed {:db* db*
+                                                :messenger mock-messenger
+                                                :config config}
+                                               {:behavior "custom"})
+      ;; Should notify about model change and tool updates
+      (let [config-calls (filter #(= (first %) :config-updated) @messenger-calls)
+            tool-calls (filter #(= (first %) :tool-server-updated) @messenger-calls)]
+        (is (match? [[:config-updated {:chat {:select-model "gpt-4.1"}}]] config-calls))
+        (is (pos? (count tool-calls))))))
+
+  (testing "Switching to behavior without defaultModel uses global default"
+    (let [db* (atom {:last-config-notified {} :mcp-clients {}})
+          messenger-calls (atom [])
+          config {:defaultModel "claude-opus-4"
+                  :behavior {"plan" {}}}
+          mock-messenger (->MockMessenger messenger-calls)]
+      (handlers/chat-selected-behavior-changed {:db* db*
+                                                :messenger mock-messenger
+                                                :config config}
+                                               {:behavior "plan"})
+      ;; Should notify about global default model and tool updates
+      (let [config-calls (filter #(= (first %) :config-updated) @messenger-calls)
+            tool-calls (filter #(= (first %) :tool-server-updated) @messenger-calls)]
+        (is (match? [[:config-updated {:chat {:select-model "claude-opus-4"}}]] config-calls))
+        (is (pos? (count tool-calls))))))
+
+  (testing "Switching behavior updates tool status"
+    (let [db* (atom {:mcp-clients {}})
+          messenger-calls (atom [])
+          config {:behavior {"plan" {:disabledTools ["eca_edit_file" "eca_write_file"]}}}
+          mock-messenger (->MockMessenger messenger-calls)]
+      (with-redefs [f.tools/native-tools (constantly [{:name "eca_edit_file"}
+                                                       {:name "eca_read_file"}])]
+        (handlers/chat-selected-behavior-changed {:db* db*
+                                                  :messenger mock-messenger
+                                                  :config config}
+                                                 {:behavior "plan"})
+        ;; Should call tool-server-updated with disabled status
+        (let [tool-calls (filter #(= (first %) :tool-server-updated) @messenger-calls)]
+          (is (pos? (count tool-calls)))
+          ;; Check that eca_edit_file tool has disabled status applied
+          (let [native-tool-call (first tool-calls)
+                tools (get-in native-tool-call [1 :tools])
+                edit-tool (first (filter #(= "eca_edit_file" (:name %)) tools))]
+            (is (some? edit-tool))
+            (is (true? (:disabled edit-tool))))))))
+
+  (testing "Switching to undefined behavior uses defaults"
+    (let [db* (atom {:last-config-notified {} :mcp-clients {}})
+          messenger-calls (atom [])
+          config {:defaultModel "fallback-model"}
+          mock-messenger (->MockMessenger messenger-calls)]
+      (handlers/chat-selected-behavior-changed {:db* db*
+                                                :messenger mock-messenger
+                                                :config config}
+                                               {:behavior "nonexistent"})
+      ;; Should notify about fallback model and tool updates
+      (let [config-calls (filter #(= (first %) :config-updated) @messenger-calls)
+            tool-calls (filter #(= (first %) :tool-server-updated) @messenger-calls)]
+        (is (match? [[:config-updated {:chat {:select-model "fallback-model"}}]] config-calls))
+        (is (pos? (count tool-calls)))))))


### PR DESCRIPTION
- Add custom behavior configuration support. #79
     - Behaviors can now define `defaultModel`, `disabledTools`, `systemPromptFile`, and `toolCall` approval rules.
     - Built-in `agent` and `plan` behaviors are pre-configured.
     - Replace `systemPromptTemplateFile` with `systemPromptFile` for complete prompt files instead of templates.
- Remove `nativeTools` configuration in favor of `toolCall` approval and `disabledTools`.
     - Native tools are now always enabled by default, controlled via `disabledTools` and `toolCall` approval.