### PR TITLE
Fix the spelling of "Editing"

### DIFF
--- a/src/eca/features/tools/filesystem.clj
+++ b/src/eca/features/tools/filesystem.clj
@@ -323,7 +323,7 @@
                                                   :description "Whether to replace all occurences of the file or just the first one (default)"}}
                   :required ["path" "original_content" "new_content"]}
     :handler #'edit-file
-    :summary-fn (constantly "Editting file")}
+    :summary-fn (constantly "Editing file")}
    "eca_preview_file_change"
    {:description (tools.util/read-tool-description "eca_preview_file_change")
     :parameters {:type "object"


### PR DESCRIPTION
"Editting" should be "Editing", so I've changed it. Does this need a changelog entry?

- [ ] I added a entry in changelog under unreleased section.
