### PR TITLE
Improve large file handling in `read-file` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Improve large file handling in `read-file` tool:
+  - Replace basic truncation notice with detailed line range information and next-step instructions.
+  - Allow users to customize default line limit through `tools.readFile.maxLines` configuration (keep the current 2000 as default).
 
 ## 0.53.0
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,6 +177,22 @@ Also check the `plan` behavior which is safer.
 
 __The `manualApproval` setting was deprecated and replaced by the `approval` one without breaking changes__
 
+### File Reading
+
+You can configure the maximum number of lines returned by the `eca_read_file` tool:
+
+```javascript
+{
+  "toolCall": {
+    "readFile": {
+      "maxLines": 1000
+    }
+  }
+}
+```
+
+Default: `2000` lines
+
 ### Custom Tools
 
 You can define your own command-line tools that the LLM can use. These are configured via the `customTools` key in your `config.json`.
@@ -389,6 +405,9 @@ ECA allows to totally customize the prompt sent to LLM via the `behavior` config
             ask?: {{key: string}: {argsMatchers?: {{[key]: string}: string[]}}},
             deny?: {{key: string}: {argsMatchers?: {{[key]: string}: string[]}}},
           };
+          readFile?: {
+            maxLines?: number;
+          };
         };
         mcpTimeoutSeconds?: number;
         lspTimeoutSeconds?: number;
@@ -438,6 +457,9 @@ ECA allows to totally customize the prompt sent to LLM via the `behavior` config
                     "eca_editor_diagnostics": {}},
           "ask": {},
           "deny": {}
+        },
+        "readFile": {
+          "maxLines": 2000
         }
       },
       "mcpTimeoutSeconds" : 60,

--- a/src/eca/config.clj
+++ b/src/eca/config.clj
@@ -84,7 +84,8 @@
                                  "eca_grep" {}
                                  "eca_editor_diagnostics" {}}
                          :ask {}
-                         :deny {}}}
+                         :deny {}}
+              :readFile {:maxLines 2000}}
    :mcpTimeoutSeconds 60
    :lspTimeoutSeconds 30
    :mcpServers {}

--- a/test/eca/features/tools/filesystem_test.clj
+++ b/test/eca/features/tools/filesystem_test.clj
@@ -110,7 +110,7 @@
     (is (match?
          {:error false
           :contents [{:type :text
-                      :text "line1\nline2"}]}
+                      :text "line1\nline2\n\n[CONTENT TRUNCATED] Showing lines 1 to 2 of 5 total lines. Use line_offset=2 parameter to read more content."}]}
          (with-redefs [slurp (constantly "line1\nline2\nline3\nline4\nline5")
                        fs/exists? (constantly true)
                        fs/readable? (constantly true)
@@ -122,7 +122,7 @@
     (is (match?
          {:error false
           :contents [{:type :text
-                      :text "line3\nline4"}]}
+                      :text "line3\nline4\n\n[CONTENT TRUNCATED] Showing lines 3 to 4 of 5 total lines. Use line_offset=4 parameter to read more content."}]}
          (with-redefs [slurp (constantly "line1\nline2\nline3\nline4\nline5")
                        fs/exists? (constantly true)
                        fs/readable? (constantly true)


### PR DESCRIPTION
- Replace basic truncation notice with detailed line range information and next-step instructions.
- Allow users to customize default line limit through `tools.readFile.maxLines` configuration (keep the current 2000 as default).
- [X] I added a entry in changelog under unreleased section.