### PR TITLE
Add :stopping status. Pass state fns to tool calls.

### DIFF
--- a/src/eca/features/tools/mcp.clj
+++ b/src/eca/features/tools/mcp.clj
@@ -5,7 +5,8 @@
    [clojure.string :as string]
    [eca.config :as config]
    [eca.logger :as logger]
-   [eca.shared :as shared])
+   [eca.shared :as shared]
+   [eca.messenger :as messenger])
   (:import
    [com.fasterxml.jackson.databind ObjectMapper]
    [io.modelcontextprotocol.client McpClient McpSyncClient]
@@ -223,7 +224,10 @@
                   (map #(assoc % :server name) tools)))
         (:mcp-clients db)))
 
-(defn call-tool! [^String name ^Map arguments db]
+(defn call-tool! [^String name ^Map arguments {:keys [db db*
+                                                      _config _messenger _behavior
+                                                      chat-id tool-call-id
+                                                      _call-state-fn state-transition-fn]}]
   (let [mcp-client (->> (vals (:mcp-clients db))
                         (keep (fn [{:keys [client tools]}]
                                 (when (some #(= name (:name %)) tools)


### PR DESCRIPTION
This is an interim commit to eventually allow tool calls to be interrupted.

In preparation, we added a :stopping status in between :executing and :stopped.  This allows us to have self transitions to create and destroy tool call resources.  The transitions and events are there, but currently they are not being exercised.  The :stopped status is considered an "inactive" status similar to an initial or terminal status.

There is one semantic behavioral change.  Previously, when a tool call was :executing and it got a :stop-requested event, that was an invalid transition.  Now, the transition happens and after the tool call is completed, a toolCallReject message is sent to the client.  Note that ECA will still wait for the tool call to complete and will not interrupt it - yet.  That is for a subsequent change.

To allow a tool call to update the tool call state, we have added two functions that are passed along to the tools.  One function retrieves the current state of the tool call and the other updates it. Currently, these functions are passed along to lower level functions but are not used.

Added tests for the new status and transitions.


- [ ] I added a entry in changelog under unreleased section.
