### PR TITLE
chore: update clojure to 1.12.2 and update flake lock

### DIFF
--- a/deps-lock.json
+++ b/deps-lock.json
@@ -2176,6 +2176,16 @@
       "hash": "sha256-JUvpyKuMzDArR9fFaj/KEUl+WcMFvxX6YFTD3/TrkZ0="
     },
     {
+      "mvn-path": "org/clojure/clojure/1.12.2/clojure-1.12.2.jar",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-pYv4B+zv7K6iIri4tH4UNo7o4yy0VAs//v/4yglTSA0="
+    },
+    {
+      "mvn-path": "org/clojure/clojure/1.12.2/clojure-1.12.2.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-55suCRfnPnPCX7N5PzFV+PD4jYAvUMJf1Sl3l3rDQiA="
+    },
+    {
       "mvn-path": "org/clojure/core.async/1.5.648/core.async-1.5.648.jar",
       "mvn-repo": "https://repo1.maven.org/maven2/",
       "hash": "sha256-Tbqwb7/HyUrn4vZoNBpl8nF19tCuigELisqwOdnNMyw="

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.12.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.2"}
         org.clojure/core.async {:mvn/version "1.8.741"}
         org.babashka/cli {:mvn/version "0.8.65"}
         com.github.clojure-lsp/jsonrpc4clj {:mvn/version "1.0.2"}

--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "lastModified": 1759733170,
+        "narHash": "sha256-TXnlsVb5Z8HXZ6mZoeOAIwxmvGHp1g4Dw89eLvIwKVI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "8913c168d1c56dc49a7718685968f38752171c3b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,9 @@
         pkgs = nixpkgs.legacyPackages.${system};
         cljpkgs = clj-nix.packages."${system}";
 
-        jdk = pkgs.jdk24_headless;
+        jdk = pkgs.jdk21_headless;
         graalvm = pkgs.graalvmPackages.graalvm-ce;
-        clojure = pkgs.clojure.override { jdk = pkgs.jdk24_headless; };
+        clojure = pkgs.clojure.override { jdk = pkgs.jdk21_headless; };
 
       in
       {


### PR DESCRIPTION
- [ ] I added a entry in changelog under unreleased section.
