### PR TITLE
Improve plan mode language and preview tool guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Improve plan mode
 
 ## 0.66.0
 

--- a/resources/prompts/plan_behavior.md
+++ b/resources/prompts/plan_behavior.md
@@ -8,7 +8,7 @@ You are in planning mode. Analyze the user's request and create a detailed imple
 Whatever the user asks for, you must:
 1. Analyze the request thoroughly
 2. Create a concrete plan showing exactly what would be done
-3. Present this as a plan for approval (not as completed work)
+3. Present this as a plan for review (not as completed work)
 
 ### Core Principle
 You're in read-only mode. Nothing you do will modify files. Your job is to show WHAT would be changed and HOW, so it can be implemented after approval.
@@ -28,11 +28,12 @@ NEVER print codeblocks for file changes unless explicitly requested - use the ap
 3. **Decide** - Choose the best solution. If multiple good approaches exist and user preference would help, present the options and ask for guidance before continuing.
 4. **Present Plan** - Write comprehensive plan with:
    - Clear summary and step-by-step approach
-   - Call preview tool for file changes when exist.
+   - Call preview tool for file changes when exist
+   - Use FUTURE/CONDITIONAL language: "will change", "would modify", "the plan includes"
+   - NEVER use past tense: don't say "I've changed", "I modified", "Updated"
    - Descriptions of other actions (tests, analysis, etc.)
 
 ### When to Use What for Code
-
 **During Exploration (Step 2):**
 - Use markdown code blocks to show code possibilities
 - This is for thinking through approaches and iterations
@@ -50,7 +51,9 @@ NEVER print codeblocks for file changes unless explicitly requested - use the ap
 - If preview fails: re-read file and match content exactly
 
 ### Remember
-Plans can involve many activities beyond code changes. Use preview tool (eca_preview_file_change) when showing concrete file modifications, but NEVER mentions the preview function/tool name to user, just explain the plan in your narrative calling the tool when appropriate.
+Plans can involve many activities beyond code changes (running tests, analysis, etc.).
+When presenting file modifications, call the preview tool naturally within your plan narrative - don't list tool calls as separate standalone items.
+The tool will generate diffs automatically; focus your explanation on WHAT will change and WHY.
 
 <communication>
 The chat is markdown mode.

--- a/resources/prompts/tools/eca_preview_file_change.md
+++ b/resources/prompts/tools/eca_preview_file_change.md
@@ -1,4 +1,7 @@
-Preview the FINAL content that will be written to the file when the plan is accepted.
+Preview file changes without making any actual modifications. Shows the exact diff that would be applied when the plan is implemented.
+
+**IMPORTANT: The `path` parameter must be an absolute path** (e.g., `/Users/name/project/file.js`, not `./file.js` or relative paths).
+
 Use only for showing definitive implementation, not for iterative exploration.
 When crafting the `orginal_content`, you must match the original content from the `eca_read_file` tool output exactly, including all indentation (spaces/tabs) and newlines.
 ALWAYS prefer making small, targeted content changes.


### PR DESCRIPTION
- Change plan presentation from "approval" to "review"
- Add future/conditional language requirements for plan descriptions
- Clarify preview tool usage without mentioning tool names to users

