### PR TITLE
add $ARGUMENTS placeholder for custom commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improved flaky test #150
 - Obfuscate env vars in /doctor.
 - Bump clj-otel to 0.2.10
+- Add $ARGUMENTS placeholder alias for custom commands.
 
 ## 0.66.1
 

--- a/src/eca/features/commands.clj
+++ b/src/eca/features/commands.clj
@@ -127,10 +127,13 @@
 (defn ^:private get-custom-command [command args custom-cmds]
   (when-let [raw-content (:content (first (filter #(= command (:name %))
                                                   custom-cmds)))]
-    (let [raw-content (string/replace raw-content "$ARGS" (string/join " " args))]
+    (let [args-joined (string/join " " args)
+          content-with-args (-> raw-content
+                                (string/replace "$ARGS" args-joined)
+                                (string/replace "$ARGUMENTS" args-joined))]
       (reduce (fn [content [i arg]]
                 (string/replace content (str "$ARG" (inc i)) arg))
-              raw-content
+              content-with-args
               (map-indexed vector args)))))
 
 (defn ^:private doctor-msg [db config]

--- a/test/eca/features/commands_test.clj
+++ b/test/eca/features/commands_test.clj
@@ -25,4 +25,9 @@
   (testing "multiple occurrences of the same placeholder are all replaced"
     (let [custom [{:name "dup" :content "$ARG1-$ARG1 $ARGS"}]]
       (is (= "x-x x y"
-             (#'f.commands/get-custom-command "dup" ["x" "y"] custom))))))
+             (#'f.commands/get-custom-command "dup" ["x" "y"] custom)))))
+
+  (testing "$ARGUMENTS is supported as alias for $ARGS"
+    (let [custom [{:name "test" :content "Process $ARGUMENTS here"}]]
+      (is (= "Process one two here"
+             (#'f.commands/get-custom-command "test" ["one" "two"] custom))))))


### PR DESCRIPTION
Some tools use $ARGUMENTS instead of $ARGS (e.g. [spec-kit](https://github.com/github/spec-kit)).
This improves the compatibility. 