### PR TITLE
Simplify credential reading, support plain-text netrc only.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,17 +25,13 @@ Code Style
 - Unit tests that use file paths and uris should rely on `h/file-path` and `h/file-uri` to avoid windows issues with slashes.
 
 Secrets Management
-- `src/eca/secrets/netrc.clj` - Netrc format parser (multi-line format: machine/login/password/port keywords)
-- `src/eca/secrets/authinfo.clj` - Authinfo format parser (single-line format: space-separated key-value pairs)
 - `src/eca/secrets.clj` - Main secrets manager for credential file operations:
-  - File discovery and priority order (.authinfo.gpg → .netrc.gpg → .authinfo → _authinfo → .netrc → _netrc)
+  - File discovery and priority order (`:netrcFile <FILE>` config → .netrc → _netrc)
   - Cross-platform path construction using io/file (handles / vs \ separators automatically)
-  - GPG decryption with caching (5-second TTL) and timeout (30s, configurable via GPG_TIMEOUT env var)
   - keyRc format parsing: [login@]machine[:port] (named after Unix "rc" config file tradition)
   - Credential matching logic (exact login match when specified, first match otherwise)
   - Permission validation (Unix: warns if not 0600; Windows: skipped)
 - Authentication flow: config `key` → credential files `keyRc` → env var `keyEnv` → OAuth
-- Security: passwords never logged; GPG decryption via clojure.java.process; cache with short TTL; subprocess timeout protection
 
 Notes
 - CI runs: bb test and bb integration-test. Ensure these pass locally before PRs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- BREAKING ECA now only supports standard plain-text netrc as credential file reading. Drop authinfo and gpg decryption support. Users can choose to pass in their own provisioned netrc file from various secure source with `:netrcFile` in ECA config.
+
 ## 0.74.0
 
 - Improved `eca_edit_file` to automatically handle whitespace and indentation differences in single-occurrence edits.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -515,6 +515,7 @@ To configure, add your OTLP collector config via `:otlp` map following [otlp aut
             systemPromptFile?: string;
         };
         otlp?: {[key: string]: string};
+        netrcFile?: string;
     }
     ```
 
@@ -530,6 +531,7 @@ To configure, add your OTLP collector config via `:otlp` map following [otlp aut
           "ollama": {"url": "http://localhost:11434"}
       },
       "defaultModel": null, // let ECA decides the default model.
+      "netrcFile": null, // search ~/.netrc or ~/_netrc when null.
       "hooks": {},
       "rules" : [],
       "commands" : [],

--- a/docs/models.md
+++ b/docs/models.md
@@ -148,7 +148,9 @@ Only set this when your provider uses a different path or expects query paramete
 
 ### Credential File Authentication
 
-Use `keyRc` in your provider config to read credentials from `~/.authinfo(.gpg)` or `~/.netrc(.gpg)` without storing keys directly in config or env vars.
+ECA also supports standard plain-text .netrc file format for reading credentials.
+
+Use `keyRc` in your provider config to read credentials from `~/.netrc` without storing keys directly in config or env vars.
 
 Example:
 
@@ -163,13 +165,20 @@ Example:
 
 keyRc lookup specification format: `[login@]machine[:port]` (e.g., `api.openai.com`, `work@api.anthropic.com`, `api.custom.com:8443`).
 
+ECA by default search .netrc file stored in user's home directory. You can also provide the path to the actual file to use with `:netrcFile` in ECA config.
+
+Tip for those wish to store their credentials encrypted with tools like gpg or age:
+
+```bash
+# via secure tempororay file
+gpg --batch -q -d ./netrc.gpg > /tmp/netrc.$$ && chmod 600 /tmp/netrc.$$ && ECA_CONFIG='{"netrcFile": "/tmp/netrc.$$"}' eca server && shred -u /tmp/netrc.$$
+```
+
 Further reading on credential file formats:
-- [Emacs authinfo documentation](https://www.gnu.org/software/emacs/manual/html_node/auth/Help-for-users.html)
 - [Curl Netrc documentation](https://everything.curl.dev/usingcurl/netrc)
 - [GNU Inetutils .netrc documentation](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html)
 
 Notes:
-- Preferred files are GPG-encrypted (`~/.authinfo.gpg` / `~/.netrc.gpg`); plaintext variants are supported.
 - Authentication priority (short): `key` > `keyRc files` > `keyEnv` > OAuth.
 - All providers with API key auth can use credential files.
 

--- a/src/eca/config.clj
+++ b/src/eca/config.clj
@@ -121,6 +121,7 @@
                      :maxEntriesPerDir 50}}
    :completion {:model "openai/gpt-4.1"
                 :systemPromptFile "prompts/inline_completion.md"}
+   :netrcFile nil
    :env "prod"})
    
 

--- a/src/eca/features/commands.clj
+++ b/src/eca/features/commands.clj
@@ -139,7 +139,7 @@
 
 (defn ^:private doctor-msg [db config]
   (let [model (llm-api/default-model db config)
-        cred-check (secrets/check-credential-files)
+        cred-check (secrets/check-credential-files (:netrcFile config))
         existing-files (filter :exists (:files cred-check))]
     (multi-str (str "ECA version: " (config/eca-version))
                ""
@@ -173,7 +173,7 @@
                                                   (System/getenv)))
                ""
                (if (seq existing-files)
-                 (str "Credential files (GPG available: " (:gpg-available cred-check) "):"
+                 (str "Credential files:"
                       (reduce
                        (fn [s file-info]
                          (str s "\n  " (:path file-info) ":"
@@ -189,7 +189,7 @@
                                 (str "\n    " (:suggestion file-info)))))
                        ""
                        existing-files))
-                 (str "Credential files: None found (GPG available: " (:gpg-available cred-check) ")")))))
+                 "Credential files: None found"))))
 
 (defn handle-command! [command args {:keys [chat-id db* config messenger full-model instructions user-messages metrics]}]
   (let [db @db*

--- a/src/eca/llm_util.clj
+++ b/src/eca/llm_util.clj
@@ -100,7 +100,7 @@
       (when-let [key (:api-key provider-auth)]
         [:auth/oauth key])
       (when-let [key (some-> (get-in config [:providers (name provider) :keyRc])
-                             (secrets/get-credential))]
+                             (secrets/get-credential (:netrcFile config)))]
         [:auth/token key])
       (when-let [key (some-> (get-in config [:providers (name provider) :keyEnv])
                              config/get-env)]

--- a/src/eca/main.clj
+++ b/src/eca/main.clj
@@ -6,6 +6,7 @@
    [borkdude.dynaload]
    [clojure.string :as string]
    [eca.config :as config]
+   [eca.secrets :as secrets]
    [eca.logger :as logger]
    [eca.server :as server]
    [eca.proxy :as proxy]))
@@ -42,7 +43,7 @@
 (def log-levels #{"error" "warn" "info" "debug"})
 
 (def cli-spec
-  {:order [:help :version :verbose :config-file]
+  {:order [:help :version :verbose :config-file :log-level]
    :spec {:help {:alias :h
                  :desc "Print the available commands and its options"}
           :version {:desc "Print eca version"}

--- a/test/eca/secrets_test.clj
+++ b/test/eca/secrets_test.clj
@@ -9,298 +9,6 @@
 
 (set! *warn-on-reflection* true)
 
-
-(deftest gpg-available-test
-  (testing "Check if GPG is available"
-    ;; This test will pass/fail based on actual system GPG availability
-    (let [result (secrets/gpg-available?)]
-      (is (boolean? result)))))
-
-(deftest decrypt-gpg-success-test
-  (testing "GPG decryption succeeds with valid file"
-    (let [temp-file (File/createTempFile "authinfo-gpg-test" ".authinfo.gpg")
-          temp-path (.getPath temp-file)
-          test-content "machine api.openai.com login apikey password sk-test-decrypted"]
-      (try
-        ;; Mock ProcessBuilder to simulate successful GPG decryption
-        (with-redefs [secrets/gpg-available? (constantly true)]
-          (let [decrypt-called? (atom false)
-                original-decrypt-gpg secrets/decrypt-gpg]
-            (with-redefs [secrets/decrypt-gpg
-                          (fn [file-path]
-                            (reset! decrypt-called? true)
-                            (if (= file-path temp-path)
-                              test-content
-                              (original-decrypt-gpg file-path)))]
-              ;; Create a dummy .gpg file
-              (spit temp-path "encrypted content")
-
-              ;; Mock credential-file-paths to return our test file
-              (with-redefs [secrets/credential-file-paths (constantly [temp-path])]
-                (let [result (secrets/get-credential "api.openai.com")]
-                  (is @decrypt-called?)
-                  (is (= "sk-test-decrypted" result)))))))
-        (finally
-          (.delete temp-file))))))
-
-(deftest decrypt-gpg-not-available-test
-  (testing "GPG decryption gracefully handles GPG not available"
-    (let [temp-file (File/createTempFile "authinfo-gpg-test" ".authinfo.gpg")
-          temp-path (.getPath temp-file)]
-      (try
-        ;; Mock gpg-available? to return false
-        (with-redefs [secrets/gpg-available? (constantly false)]
-          (spit temp-path "encrypted content")
-
-          (with-redefs [secrets/credential-file-paths (constantly [temp-path])]
-            ;; Should return nil when GPG not available
-            (is (nil? (secrets/get-credential "api.openai.com")))))
-        (finally
-          (.delete temp-file))))))
-
-(deftest decrypt-gpg-failure-test
-  (testing "GPG decryption handles failure gracefully"
-    (let [temp-file (File/createTempFile "authinfo-gpg-test" ".authinfo.gpg")
-          temp-path (.getPath temp-file)]
-      (try
-        ;; Mock decrypt-gpg to return nil (decryption failure)
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (constantly nil)]
-          (spit temp-path "encrypted content")
-
-          (with-redefs [secrets/credential-file-paths (constantly [temp-path])]
-            ;; Should return nil when decryption fails
-            (is (nil? (secrets/get-credential "api.openai.com")))))
-        (finally
-          (.delete temp-file))))))
-
-(deftest gpg-file-priority-test
-  (testing "GPG file has highest priority"
-    (let [authinfo-gpg-file (File/createTempFile "test" ".authinfo.gpg")
-          authinfo-file (File/createTempFile "test" ".authinfo")
-          authinfo-gpg-path (.getPath authinfo-gpg-file)
-          authinfo-path (.getPath authinfo-file)]
-      (try
-        ;; Create different passwords in each file
-        (spit authinfo-file "machine api.openai.com login apikey password from-authinfo")
-
-        ;; Mock GPG to return different password
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (fn [file-path]
-                                            (when (= file-path authinfo-gpg-path)
-                                              "machine api.openai.com login apikey password from-authinfo-gpg"))]
-          (with-redefs [secrets/credential-file-paths (constantly [authinfo-gpg-path authinfo-path])]
-            ;; Should use GPG-encrypted file first
-            (is (= "from-authinfo-gpg" (secrets/get-credential "api.openai.com")))))
-        (finally
-          (.delete authinfo-gpg-file)
-          (.delete authinfo-file))))))
-
-(deftest gpg-fallback-to-plaintext-test
-  (testing "Falls back to plaintext when GPG decryption fails"
-    (let [authinfo-gpg-file (File/createTempFile "test" ".authinfo.gpg")
-          authinfo-file (File/createTempFile "test" ".authinfo")
-          authinfo-gpg-path (.getPath authinfo-gpg-file)
-          authinfo-path (.getPath authinfo-file)]
-      (try
-        (spit authinfo-file "machine api.openai.com login apikey password from-authinfo")
-
-        ;; Mock GPG to fail decryption
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (constantly nil)]
-          (with-redefs [secrets/credential-file-paths (constantly [authinfo-gpg-path authinfo-path])]
-            ;; Should fall back to plaintext file
-            (is (= "from-authinfo" (secrets/get-credential "api.openai.com")))))
-        (finally
-          (.delete authinfo-gpg-file)
-          (.delete authinfo-file))))))
-
-(deftest netrc-gpg-decryption-test
-  (testing "GPG decryption works for .netrc.gpg files"
-    (let [netrc-gpg-file (File/createTempFile "test" ".netrc.gpg")
-          netrc-gpg-path (.getPath netrc-gpg-file)
-          test-content "machine api.openai.com\nlogin apikey\npassword from-netrc-gpg\n"]
-      (try
-        (spit netrc-gpg-file "encrypted content")
-
-        ;; Mock GPG to return netrc format content
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (fn [file-path]
-                                            (when (= file-path netrc-gpg-path)
-                                              test-content))]
-          (with-redefs [secrets/credential-file-paths (constantly [netrc-gpg-path])]
-            ;; Should decrypt and parse netrc format
-            (is (= "from-netrc-gpg" (secrets/get-credential "api.openai.com")))))
-        (finally
-          (.delete netrc-gpg-file))))))
-
-(deftest netrc-gpg-priority-test
-  (testing ".netrc.gpg has priority over .netrc"
-    (let [netrc-gpg-file (File/createTempFile "test" ".netrc.gpg")
-          netrc-file (File/createTempFile "test" ".netrc")
-          netrc-gpg-path (.getPath netrc-gpg-file)
-          netrc-path (.getPath netrc-file)]
-      (try
-        ;; Create different passwords in each file
-        (spit netrc-file "machine api.openai.com\nlogin apikey\npassword from-netrc\n")
-
-        ;; Mock GPG to return different password
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (fn [file-path]
-                                            (when (= file-path netrc-gpg-path)
-                                              "machine api.openai.com\nlogin apikey\npassword from-netrc-gpg\n"))]
-          (with-redefs [secrets/credential-file-paths (constantly [netrc-gpg-path netrc-path])]
-            ;; Should use .netrc.gpg file first
-            (is (= "from-netrc-gpg" (secrets/get-credential "api.openai.com")))))
-        (finally
-          (.delete netrc-gpg-file)
-          (.delete netrc-file))))))
-
-(deftest netrc-gpg-fallback-test
-  (testing "Falls back to .netrc when .netrc.gpg decryption fails"
-    (let [netrc-gpg-file (File/createTempFile "test" ".netrc.gpg")
-          netrc-file (File/createTempFile "test" ".netrc")
-          netrc-gpg-path (.getPath netrc-gpg-file)
-          netrc-path (.getPath netrc-file)]
-      (try
-        (spit netrc-file "machine api.openai.com\nlogin apikey\npassword from-netrc\n")
-
-        ;; Mock GPG to fail decryption
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (constantly nil)]
-          (with-redefs [secrets/credential-file-paths (constantly [netrc-gpg-path netrc-path])]
-            ;; Should fall back to plaintext .netrc file
-            (is (= "from-netrc" (secrets/get-credential "api.openai.com")))))
-        (finally
-          (.delete netrc-gpg-file)
-          (.delete netrc-file))))))
-
-
-(deftest windows-authinfo-gpg-test
-  (testing "Windows _authinfo.gpg file is supported"
-    (let [authinfo-gpg-file (File/createTempFile "test" "_authinfo.gpg")
-          authinfo-gpg-path (.getPath authinfo-gpg-file)
-          test-content "machine api.openai.com login apikey password from-windows-authinfo-gpg"]
-      (try
-        (spit authinfo-gpg-file "encrypted content")
-
-        ;; Mock GPG to return authinfo format content
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (fn [file-path]
-                                            (when (= file-path authinfo-gpg-path)
-                                              test-content))]
-          (with-redefs [secrets/credential-file-paths (constantly [authinfo-gpg-path])]
-            ;; Should decrypt and parse authinfo format from Windows GPG file
-            (is (= "from-windows-authinfo-gpg" (secrets/get-credential "api.openai.com")))))
-        (finally
-          (.delete authinfo-gpg-file))))))
-
-(deftest windows-netrc-gpg-test
-  (testing "Windows _netrc.gpg file is supported"
-    (let [netrc-gpg-file (File/createTempFile "test" "_netrc.gpg")
-          netrc-gpg-path (.getPath netrc-gpg-file)
-          test-content "machine api.openai.com\nlogin apikey\npassword from-windows-netrc-gpg\n"]
-      (try
-        (spit netrc-gpg-file "encrypted content")
-
-        ;; Mock GPG to return netrc format content
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (fn [file-path]
-                                            (when (= file-path netrc-gpg-path)
-                                              test-content))]
-          (with-redefs [secrets/credential-file-paths (constantly [netrc-gpg-path])]
-            ;; Should decrypt and parse netrc format from Windows GPG file
-            (is (= "from-windows-netrc-gpg" (secrets/get-credential "api.openai.com")))))
-        (finally
-          (.delete netrc-gpg-file))))))
-
-(deftest windows-gpg-priority-test
-  (testing "Windows GPG files follow correct priority order"
-    (let [authinfo-gpg-file (File/createTempFile "test" "_authinfo.gpg")
-          authinfo-file (File/createTempFile "test" "_authinfo")
-          netrc-gpg-file (File/createTempFile "test" "_netrc.gpg")
-          netrc-file (File/createTempFile "test" "_netrc")
-          authinfo-gpg-path (.getPath authinfo-gpg-file)
-          authinfo-path (.getPath authinfo-file)
-          netrc-gpg-path (.getPath netrc-gpg-file)
-          netrc-path (.getPath netrc-file)]
-      (try
-        ;; Create different passwords in each file
-        (spit authinfo-file "machine api.test.com login apikey password from-authinfo")
-        (spit netrc-file "machine api.test.com\nlogin apikey\npassword from-netrc\n")
-
-        ;; Test 1: _authinfo.gpg has priority over _authinfo
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (fn [file-path]
-                                            (when (= file-path authinfo-gpg-path)
-                                              "machine api.test.com login apikey password from-authinfo-gpg"))]
-          (with-redefs [secrets/credential-file-paths (constantly [authinfo-gpg-path authinfo-path])]
-            (is (= "from-authinfo-gpg" (secrets/get-credential "api.test.com"))
-                "_authinfo.gpg should have priority over _authinfo")))
-
-        ;; Test 2: _authinfo has priority over _netrc.gpg
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (fn [file-path]
-                                            (when (= file-path netrc-gpg-path)
-                                              "machine api.test.com\nlogin apikey\npassword from-netrc-gpg\n"))]
-          (with-redefs [secrets/credential-file-paths (constantly [authinfo-path netrc-gpg-path])]
-            (is (= "from-authinfo" (secrets/get-credential "api.test.com"))
-                "_authinfo should have priority over _netrc.gpg")))
-
-        ;; Test 3: _netrc.gpg has priority over _netrc
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (fn [file-path]
-                                            (when (= file-path netrc-gpg-path)
-                                              "machine api.test.com\nlogin apikey\npassword from-netrc-gpg\n"))]
-          (with-redefs [secrets/credential-file-paths (constantly [netrc-gpg-path netrc-path])]
-            (is (= "from-netrc-gpg" (secrets/get-credential "api.test.com"))
-                "_netrc.gpg should have priority over _netrc")))
-        (finally
-          (.delete authinfo-gpg-file)
-          (.delete authinfo-file)
-          (.delete netrc-gpg-file)
-          (.delete netrc-file))))))
-
-
-(deftest gpg-timeout-test
-  (testing "GPG decryption handles timeout gracefully"
-    (let [temp-file (File/createTempFile "test" ".authinfo.gpg")
-          temp-path (.getPath temp-file)
-          decrypt-called? (atom false)]
-      (try
-        (spit temp-path "encrypted content")
-
-        ;; Mock decrypt-gpg to simulate timeout behavior
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (fn [_file-path]
-                                            (reset! decrypt-called? true)
-                                            ;; Simulate timeout by returning nil
-                                            nil)]
-          (with-redefs [secrets/credential-file-paths (constantly [temp-path])]
-            ;; Should return nil when GPG times out
-            (is (nil? (secrets/get-credential "api.openai.com")))
-            (is @decrypt-called? "decrypt-gpg should have been called")))
-        (finally
-          (.delete temp-file))))))
-
-(deftest gpg-timeout-custom-value-test
-  (testing "GPG timeout respects GPG_TIMEOUT environment variable"
-    (let [temp-file (File/createTempFile "test" ".authinfo.gpg")
-          temp-path (.getPath temp-file)]
-      (try
-        (spit temp-path "encrypted content")
-
-        ;; Test with custom timeout via environment variable
-        ;; We can't actually test the real timeout behavior without making the test slow,
-        ;; but we can verify the env var is read
-        (with-redefs [secrets/gpg-available? (constantly true)]
-          ;; The actual timeout behavior is tested via the code path,
-          ;; this test documents that GPG_TIMEOUT can be configured
-          (is true "GPG_TIMEOUT environment variable is supported"))
-        (finally
-          (.delete temp-file))))))
-
-
 (deftest parse-key-rc-simple-machine-test
   (testing "Parse simple machine name"
     (is (= {:machine "api.openai.com" :login nil :port nil}
@@ -325,7 +33,6 @@
   (testing "Handle empty string"
     (is (nil? (secrets/parse-key-rc "")))
     (is (nil? (secrets/parse-key-rc nil)))))
-
 
 (deftest get-credential-simple-machine-test
   (testing "Get credential with simple machine name"
@@ -414,7 +121,6 @@
         (finally
           (.delete temp-file))))))
 
-
 (deftest load-netrc-format-test
   (testing "Load credentials from .netrc format"
     (let [temp-file (File/createTempFile "test" ".netrc")
@@ -426,62 +132,6 @@
           (is (= "sk-proj-123" (secrets/get-credential "api.openai.com"))))
         (finally
           (.delete temp-file))))))
-
-(deftest load-authinfo-format-test
-  (testing "Load credentials from .authinfo format"
-    (let [temp-file (File/createTempFile "test" ".authinfo")
-          temp-path (.getPath temp-file)]
-      (try
-        (spit temp-path "machine api.openai.com login apikey password sk-proj-123")
-
-        (with-redefs [secrets/credential-file-paths (constantly [temp-path])]
-          (is (= "sk-proj-123" (secrets/get-credential "api.openai.com"))))
-        (finally
-          (.delete temp-file))))))
-
-(deftest load-underscore-authinfo-format-test
-  (testing "Load credentials from _authinfo format (Windows)"
-    (let [temp-file (File/createTempFile "test" "_authinfo")
-          temp-path (.getPath temp-file)]
-      (try
-        (spit temp-path "machine api.openai.com login apikey password sk-proj-underscore")
-
-        (with-redefs [secrets/credential-file-paths (constantly [temp-path])]
-          (is (= "sk-proj-underscore" (secrets/get-credential "api.openai.com"))))
-        (finally
-          (.delete temp-file))))))
-
-
-(deftest file-priority-order-test
-  (testing "Files are checked in priority order"
-    (let [authinfo-gpg-file (File/createTempFile "test" ".authinfo.gpg")
-          authinfo-file (File/createTempFile "test" ".authinfo")
-          netrc-file (File/createTempFile "test" ".netrc")
-          authinfo-gpg-path (.getPath authinfo-gpg-file)
-          authinfo-path (.getPath authinfo-file)
-          netrc-path (.getPath netrc-file)]
-      (try
-        ;; Create different passwords in each file
-        (spit authinfo-gpg-path "machine api.openai.com login apikey password from-authinfo-gpg")
-        (spit authinfo-path "machine api.openai.com login apikey password from-authinfo")
-        (spit netrc-path "machine api.openai.com\nlogin apikey\npassword from-netrc\n")
-
-        ;; authinfo.gpg should be checked first (but we can't decrypt in test, so it will fail)
-        ;; authinfo should be checked second
-        (with-redefs [secrets/credential-file-paths (constantly [authinfo-gpg-path authinfo-path netrc-path])]
-          ;; Since we can't decrypt .gpg in test, it should fall through to .authinfo
-          (is (= "from-authinfo" (secrets/get-credential "api.openai.com"))))
-
-        ;; If only netrc exists, should use that
-        (.delete authinfo-gpg-file)
-        (.delete authinfo-file)
-        (with-redefs [secrets/credential-file-paths (constantly [authinfo-gpg-path authinfo-path netrc-path])]
-          (is (= "from-netrc" (secrets/get-credential "api.openai.com"))))
-        (finally
-          (.delete authinfo-gpg-file)
-          (.delete authinfo-file)
-          (.delete netrc-file))))))
-
 
 (deftest multiple-credentials-same-machine-test
   (testing "Handle multiple credentials for same machine"
@@ -505,7 +155,6 @@
           (is (= "sk-proj-789" (secrets/get-credential "api.openai.com"))))
         (finally
           (.delete temp-file))))))
-
 
 (deftest port-matching-test
   (testing "Port matching with exact match required"
@@ -561,37 +210,15 @@
         (finally
           (.delete temp-file))))))
 
-(deftest load-credentials-from-multiple-files-test
-  (testing "Load credentials from all available files, not just the first"
-    (let [authinfo-file (File/createTempFile "test" ".authinfo")
-          netrc-file (File/createTempFile "test" ".netrc")
-          authinfo-path (.getPath authinfo-file)
-          netrc-path (.getPath netrc-file)]
-      (try
-        ;; Create different credentials in each file
-        (spit authinfo-path "machine api.openai.com login apikey password from-authinfo")
-        (spit netrc-path "machine api.anthropic.com\nlogin apikey\npassword from-netrc\n")
-
-        (with-redefs [secrets/credential-file-paths (constantly [authinfo-path netrc-path])]
-          ;; Should find credential from authinfo file
-          (is (= "from-authinfo" (secrets/get-credential "api.openai.com")))
-
-          ;; Should also find credential from netrc file
-          (is (= "from-netrc" (secrets/get-credential "api.anthropic.com"))))
-        (finally
-          (.delete authinfo-file)
-          (.delete netrc-file))))))
-
-
-(deftest home-directory-path-test
+(deftest netrc-file-path-test
+  (testing "Use specified netrc file when provided"
+    (let [paths (secrets/credential-file-paths "/dev/test/mynetrc")]
+      (is (= ["/dev/test/mynetrc"] paths))))
   (testing "Home directory is resolved correctly across platforms"
-    (let [paths (secrets/credential-file-paths)]
+    (let [paths (secrets/credential-file-paths nil)]
       (is (seq paths))
       (is (every? string? paths))
       ;; Should contain standard credential files
-      (is (some #(string/ends-with? % ".authinfo.gpg") paths))
-      (is (some #(string/ends-with? % ".authinfo") paths))
-      (is (some #(string/ends-with? % "_authinfo") paths))
       (is (some #(string/ends-with? % ".netrc") paths))
       ;; Windows-specific file should be present
       (is (some #(string/ends-with? % "_netrc") paths)))))
@@ -608,7 +235,6 @@
           (is (= "sk-test-123" (secrets/get-credential "api.openai.com"))))
         (finally
           (.delete temp-file))))))
-
 
 (deftest no-password-logging-in-debug-test
   (testing "Debug logs do not contain passwords"
@@ -653,68 +279,6 @@
                 "Password should not appear in error messages")))
         (finally
           (.delete temp-file))))))
-
-
-(deftest gpg-cache-performance-test
-  (testing "GPG decryption results are cached to improve performance"
-    (let [temp-file (File/createTempFile "test" ".authinfo.gpg")
-          temp-path (.getPath temp-file)
-          decrypt-count (atom 0)
-          test-content "machine api.openai.com login apikey password sk-cached-password"]
-      (try
-        (spit temp-path "encrypted content")
-
-        ;; Mock GPG to count decryption calls
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (let [original-decrypt secrets/decrypt-gpg]
-                                            (fn [file-path]
-                                              (if (= file-path temp-path)
-                                                (do
-                                                  (swap! decrypt-count inc)
-                                                  test-content)
-                                                (original-decrypt file-path))))
-                      secrets/credential-file-paths (constantly [temp-path])]
-          ;; First call should decrypt
-          (is (= "sk-cached-password" (secrets/get-credential "api.openai.com")))
-          (is (= 1 @decrypt-count) "First call should decrypt")
-
-          ;; Second call within cache TTL should use cache
-          (is (= "sk-cached-password" (secrets/get-credential "api.openai.com")))
-          ;; Note: Due to how caching is implemented, this might still increment
-          ;; but the cache should be checked first
-          (is (<= @decrypt-count 2) "Second call should use cache or decrypt once more"))
-        (finally
-          (.delete temp-file))))))
-
-(deftest gpg-cache-invalidation-test
-  (testing "GPG cache is invalidated after TTL"
-    (let [temp-file (File/createTempFile "test" ".authinfo.gpg")
-          temp-path (.getPath temp-file)
-          decrypt-count (atom 0)
-          test-content "machine api.openai.com login apikey password sk-test-ttl"]
-      (try
-        (spit temp-path "encrypted content")
-
-        ;; Mock GPG and cache to test TTL
-        (with-redefs [secrets/gpg-available? (constantly true)
-                      secrets/decrypt-gpg (let [original-decrypt secrets/decrypt-gpg]
-                                            (fn [file-path]
-                                              (if (= file-path temp-path)
-                                                (do
-                                                  (swap! decrypt-count inc)
-                                                  test-content)
-                                                (original-decrypt file-path))))
-                      secrets/credential-file-paths (constantly [temp-path])]
-          ;; First call
-          (is (= "sk-test-ttl" (secrets/get-credential "api.openai.com")))
-          (let [first-count @decrypt-count]
-            ;; Wait for cache to expire (5+ seconds)
-            ;; For testing purposes, we'll just verify the mechanism exists
-            ;; rather than actually waiting 5 seconds
-            (is (>= first-count 1) "Should have decrypted at least once")))
-        (finally
-          (.delete temp-file))))))
-
 
 (deftest permission-validation-unix-test
   (testing "Permission validation on Unix systems"
@@ -795,45 +359,18 @@
         (is true "Windows detected - permission checks should be skipped")
         (is true "Non-Windows system - permission checks should run")))))
 
-
 (deftest file-priority-comprehensive-test
   (testing "Comprehensive file priority order validation"
-    (let [authinfo-gpg-file (File/createTempFile "test" ".authinfo.gpg")
-          netrc-gpg-file (File/createTempFile "test" ".netrc.gpg")
-          authinfo-file (File/createTempFile "test" ".authinfo")
-          authinfo-win-file (File/createTempFile "test" "_authinfo")
-          netrc-file (File/createTempFile "test" ".netrc")
+    (let [netrc-file (File/createTempFile "test" ".netrc")
           netrc-win-file (File/createTempFile "test" "_netrc")
-          authinfo-gpg-path (.getPath authinfo-gpg-file)
-          netrc-gpg-path (.getPath netrc-gpg-file)
-          authinfo-path (.getPath authinfo-file)
-          authinfo-win-path (.getPath authinfo-win-file)
           netrc-path (.getPath netrc-file)
           netrc-win-path (.getPath netrc-win-file)]
       (try
         ;; Create different passwords in each file
-        (spit authinfo-path "machine api.test.com login apikey password from-authinfo")
-        (spit authinfo-win-path "machine api.test.com login apikey password from-authinfo-win")
         (spit netrc-path "machine api.test.com\nlogin apikey\npassword from-netrc\n")
         (spit netrc-win-path "machine api.test.com\nlogin apikey\npassword from-netrc-win\n")
 
-        ;; Test priority: authinfo.gpg > netrc.gpg > authinfo > _authinfo > netrc > _netrc
-        ;; Since GPG will fail to decrypt, should fall through to authinfo
-        (with-redefs [secrets/credential-file-paths
-                      (constantly [authinfo-gpg-path netrc-gpg-path authinfo-path authinfo-win-path netrc-path netrc-win-path])]
-          (is (= "from-authinfo" (secrets/get-credential "api.test.com"))
-              "Should use .authinfo when .gpg files fail"))
-
-        ;; Test with only _authinfo and netrc files (no .authinfo or .gpg files)
-        (.delete authinfo-gpg-file)
-        (.delete netrc-gpg-file)
-        (.delete authinfo-file)
-        (with-redefs [secrets/credential-file-paths (constantly [authinfo-win-path netrc-path netrc-win-path])]
-          (is (= "from-authinfo-win" (secrets/get-credential "api.test.com"))
-              "Should use _authinfo before .netrc"))
-
         ;; Test with only netrc files
-        (.delete authinfo-win-file)
         (with-redefs [secrets/credential-file-paths (constantly [netrc-path netrc-win-path])]
           (is (= "from-netrc" (secrets/get-credential "api.test.com"))
               "Should use .netrc before _netrc"))
@@ -844,43 +381,14 @@
           (is (= "from-netrc-win" (secrets/get-credential "api.test.com"))
               "Should use _netrc when others don't exist"))
         (finally
-          (.delete authinfo-gpg-file)
-          (.delete netrc-gpg-file)
-          (.delete authinfo-file)
-          (.delete authinfo-win-file)
           (.delete netrc-file)
           (.delete netrc-win-file))))))
-
-
-(deftest end-to-end-credential-resolution-test
-  (testing "End-to-end credential resolution with all components"
-    (let [netrc-file (File/createTempFile "test" ".netrc")
-          authinfo-file (File/createTempFile "test" ".authinfo")
-          netrc-path (.getPath netrc-file)
-          authinfo-path (.getPath authinfo-file)]
-      (try
-        ;; Create credentials in different files
-        (spit netrc-path (str "machine api.openai.com\nlogin apikey\npassword sk-openai-123\n\n"
-                              "machine api.anthropic.com\nlogin work\npassword sk-ant-work-456\n"))
-        (spit authinfo-path "machine custom.api login admin password custom-789 port 8443")
-
-        (with-redefs [secrets/credential-file-paths (constantly [authinfo-path netrc-path])]
-          ;; Test various lookups
-          (is (= "sk-openai-123" (secrets/get-credential "api.openai.com")))
-          (is (= "sk-ant-work-456" (secrets/get-credential "work@api.anthropic.com")))
-          (is (= "custom-789" (secrets/get-credential "custom.api:8443")))
-          (is (nil? (secrets/get-credential "nonexistent.com"))))
-        (finally
-          (.delete netrc-file)
-          (.delete authinfo-file))))))
 
 (deftest check-credential-files-no-files-test
   (testing "check-credential-files with no credential files"
     (with-redefs [secrets/credential-file-paths (constantly [])]
-      (let [result (secrets/check-credential-files)]
+      (let [result (secrets/check-credential-files nil)]
         (is (map? result))
-        (is (contains? result :gpg-available))
-        (is (boolean? (:gpg-available result)))
         (is (vector? (:files result)))
         (is (empty? (:files result)))))))
 
@@ -892,49 +400,25 @@
         ;; Create a valid netrc file
         (spit temp-path "machine api.test.com\nlogin apikey\npassword test-key-123\n")
 
-        (with-redefs [secrets/credential-file-paths (constantly [temp-path])]
-          (let [result (secrets/check-credential-files)
-                file-info (first (:files result))]
-            (is (= temp-path (:path file-info)))
-            (is (true? (:exists file-info)))
-            (is (true? (:readable file-info)))
-            (is (false? (:is-gpg file-info)))
-            (is (= 1 (:credentials-count file-info)))
-            (is (string/includes? (:suggestion file-info) "Consider encrypting with GPG"))))
-        (finally
-          (.delete temp-file))))))
+        (let [result (secrets/check-credential-files temp-path)
+              file-info (first (:files result))]
+          (is (= temp-path (:path file-info)))
+          (is (true? (:exists file-info)))
+          (is (true? (:readable file-info)))
+          (is (= 1 (:credentials-count file-info))))
 
-(deftest check-credential-files-gpg-file-test
-  (testing "check-credential-files with GPG file"
-    (let [temp-file (File/createTempFile "test" ".authinfo.gpg")
-          temp-path (.getPath temp-file)]
-      (try
-        ;; Create a dummy GPG file (won't decrypt without real GPG)
-        (spit temp-path "dummy gpg content")
-
-        (with-redefs [secrets/credential-file-paths (constantly [temp-path])]
-          (let [result (secrets/check-credential-files)
-                file-info (first (:files result))]
-            (is (= temp-path (:path file-info)))
-            (is (true? (:exists file-info)))
-            (is (true? (:readable file-info)))
-            (is (true? (:is-gpg file-info)))
-            ;; No suggestion for GPG files
-            (is (nil? (:suggestion file-info)))))
         (finally
           (.delete temp-file))))))
 
 (deftest check-credential-files-nonexistent-test
   (testing "check-credential-files with nonexistent file"
-    (let [nonexistent-path "/tmp/nonexistent-credential-file.netrc"]
-      (with-redefs [secrets/credential-file-paths (constantly [nonexistent-path])]
-        (let [result (secrets/check-credential-files)
-              file-info (first (:files result))]
-          (is (= nonexistent-path (:path file-info)))
-          (is (false? (:exists file-info)))
-          (is (nil? (:readable file-info)))
-          (is (nil? (:credentials-count file-info)))
-          (is (nil? (:suggestion file-info))))))))
+    (let [nonexistent-path "/tmp/nonexistent-credential-file.netrc"
+          result (secrets/check-credential-files nonexistent-path)
+          file-info (first (:files result))]
+      (is (= nonexistent-path (:path file-info)))
+      (is (false? (:exists file-info)))
+      (is (nil? (:readable file-info)))
+      (is (nil? (:credentials-count file-info))))))
 
 (deftest check-credential-files-parse-error-test
   (testing "check-credential-files with unparseable file"
@@ -944,12 +428,11 @@
         ;; Create an invalid file that will cause parse error
         (spit temp-path "invalid content that can't be parsed as netrc")
 
-        (with-redefs [secrets/credential-file-paths (constantly [temp-path])
-                      ;; Mock load-credentials-from-file to throw an error
-                      secrets/load-credentials-from-file
+        ;; Mock load-credentials-from-file to throw an error
+        (with-redefs [secrets/load-credentials-from-file
                       (fn [_path]
                         (throw (Exception. "Parse error: invalid format")))]
-          (let [result (secrets/check-credential-files)
+          (let [result (secrets/check-credential-files temp-path)
                 file-info (first (:files result))]
             (is (= temp-path (:path file-info)))
             (is (true? (:exists file-info)))
@@ -961,18 +444,18 @@
 (deftest check-credential-files-multiple-files-test
   (testing "check-credential-files with multiple credential files"
     (let [netrc-file (File/createTempFile "test" ".netrc")
-          authinfo-file (File/createTempFile "test" ".authinfo")
+          netrc-win-file (File/createTempFile "test" "_netrc")
           netrc-path (.getPath netrc-file)
-          authinfo-path (.getPath authinfo-file)
-          nonexistent-path "/tmp/nonexistent.authinfo.gpg"]
+          netrc-win-path (.getPath netrc-win-file)
+          nonexistent-path "/tmp/nonexistent"]
       (try
         ;; Create valid files
         (spit netrc-path "machine api.test.com\nlogin apikey\npassword test-key-123\n")
-        (spit authinfo-path "machine api.other.com login user password pass-456")
+        (spit netrc-win-path "machine api.other.com login user password pass-456")
 
         (with-redefs [secrets/credential-file-paths
-                      (constantly [nonexistent-path netrc-path authinfo-path])]
-          (let [result (secrets/check-credential-files)
+                      (constantly [nonexistent-path netrc-path netrc-win-path])]
+          (let [result (secrets/check-credential-files nil)
                 files (:files result)]
             (is (= 3 (count files)))
             ;; First file doesn't exist
@@ -985,4 +468,4 @@
             (is (= 1 (:credentials-count (nth files 2))))))
         (finally
           (.delete netrc-file)
-          (.delete authinfo-file))))))
+          (.delete netrc-win-file))))))


### PR DESCRIPTION
This is a follow up on https://github.com/editor-code-assistant/eca/pull/146 to simplify our credential reading logic.

1. drop authinfo and gpg decryption logic out of scope
2. added a --netrc-file option for flexible use-cases

Basically same as curl's implementation.

- [x] I added a entry in changelog under unreleased section.
