### PR TITLE
workaround for failing to download deps during win int testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,13 @@ jobs:
           bb: '1.12.200'
 
       - name: Generate embedded binary
-        run: bb prod-cli
+        run: |
+          # On Windows, babashka.deps/clojure sometimes fails with
+          # AccessDeniedException exception when renaming temp files
+          # while downloading dependencies. Workaround: offload some
+          # of the deps download to the clojure CLI tool.
+          clojure -P
+          bb prod-cli
 
       - name: Run integration tests
         run: bb integration-test


### PR DESCRIPTION
HI,

could you please consider a workaround for the `prod-cli` build step failing on Windows during CI integration test setup?

The issue seems to stem from `babashka.deps/clojure`, which builds the uberjar. On Windows, it occasionally fails to download dependencies due to an `AccessDeniedException` when renaming a temporary file during the downloads. The exact cause is unclear, but pre downloading some of the dependencies using the clojure CLI directly appears to avoidthe problem.

stack trace of the error:

```
{:clojure.main/message
 "Execution error (AccessDeniedException) at sun.nio.fs.WindowsException/translateToIOException (WindowsException.java:89).\r\nC:\\Users\\ikappaki\\.m2\\repository\\io\\opentelemetry\\opentelemetry-exporter-common\\1.54.1\\_remote.repositories.12805229861750152054.tmp -> C:\\Users\\ikappaki\\.m2\\repository\\io\\opentelemetry\\opentelemetry-exporter-common\\1.54.1\\_remote.repositories\r\n",
 :clojure.main/triage
 {:clojure.error/class java.nio.file.AccessDeniedException,
  :clojure.error/line 89,
  :clojure.error/cause
  "C:\\Users\\ikappaki\\.m2\\repository\\io\\opentelemetry\\opentelemetry-exporter-common\\1.54.1\\_remote.repositories.12805229861750152054.tmp -> C:\\Users\\ikappaki\\.m2\\repository\\io\\opentelemetry\\opentelemetry-exporter-common\\1.54.1\\_remote.repositories",
  :clojure.error/symbol
  sun.nio.fs.WindowsException/translateToIOException,
  :clojure.error/source "WindowsException.java",
  :clojure.error/phase :execution},
 :clojure.main/trace
 {:via
  [{:type java.io.UncheckedIOException,
    :message
    "java.nio.file.AccessDeniedException: C:\\Users\\ikappaki\\.m2\\repository\\io\\opentelemetry\\opentelemetry-exporter-common\\1.54.1\\_remote.repositories.12805229861750152054.tmp -> C:\\Users\\ikappaki\\.m2\\repository\\io\\opentelemetry\\opentelemetry-exporter-common\\1.54.1\\_remote.repositories",
    :at
    [org.eclipse.aether.internal.impl.DefaultTrackingFileManager
     update
     "DefaultTrackingFileManager.java"
     121]}
   {:type java.nio.file.AccessDeniedException,
    :message
    "C:\\Users\\ikappaki\\.m2\\repository\\io\\opentelemetry\\opentelemetry-exporter-common\\1.54.1\\_remote.repositories.12805229861750152054.tmp -> C:\\Users\\ikappaki\\.m2\\repository\\io\\opentelemetry\\opentelemetry-exporter-common\\1.54.1\\_remote.repositories",
    :at
    [sun.nio.fs.WindowsException
     translateToIOException
     "WindowsException.java"
     89]}],
  :trace
  [[sun.nio.fs.WindowsException
    translateToIOException
    "WindowsException.java"
    89]
   [sun.nio.fs.WindowsException
    rethrowAsIOException
    "WindowsException.java"
    103]
   [sun.nio.fs.WindowsFileCopy move "WindowsFileCopy.java" 317]
   [sun.nio.fs.WindowsFileSystemProvider
    move
    "WindowsFileSystemProvider.java"
    293]
   [java.nio.file.Files move "Files.java" 1432]
   [org.eclipse.aether.util.FileUtils$2 move "FileUtils.java" 121]
   [org.eclipse.aether.util.FileUtils writeFile "FileUtils.java" 192]
   [org.eclipse.aether.util.FileUtils writeFile "FileUtils.java" 152]
   [org.eclipse.aether.internal.impl.DefaultTrackingFileManager
    update
    "DefaultTrackingFileManager.java"
    108]
   [org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManager
    addRepo
    "EnhancedLocalRepositoryManager.java"
    274]
   [org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManager
    addArtifact
    "EnhancedLocalRepositoryManager.java"
    252]
   [org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManager
    add
    "EnhancedLocalRepositoryManager.java"
    225]
   [org.eclipse.aether.internal.impl.DefaultArtifactResolver
    evaluateDownloads
    "DefaultArtifactResolver.java"
    680]
   [org.eclipse.aether.internal.impl.DefaultArtifactResolver
    performDownloads
    "DefaultArtifactResolver.java"
    592]
   [org.eclipse.aether.internal.impl.DefaultArtifactResolver
    resolve
    "DefaultArtifactResolver.java"
    478]
   [org.eclipse.aether.internal.impl.DefaultArtifactResolver
    resolveArtifacts
    "DefaultArtifactResolver.java"
    278]
   [org.eclipse.aether.internal.impl.DefaultArtifactResolver
    resolveArtifact
    "DefaultArtifactResolver.java"
    255]
   [org.apache.maven.repository.internal.DefaultArtifactDescriptorReader
    loadPom
    "DefaultArtifactDescriptorReader.java"
    240]
   [org.apache.maven.repository.internal.DefaultArtifactDescriptorReader
    readArtifactDescriptor
    "DefaultArtifactDescriptorReader.java"
    171]
   [org.eclipse.aether.internal.impl.DefaultRepositorySystem
    readArtifactDescriptor
    "DefaultRepositorySystem.java"
    286]
   [clojure.tools.deps.extensions.maven$read_descriptor
    invokeStatic
    "maven.clj"
    115]
   [clojure.tools.deps.extensions.maven$read_descriptor
    invoke
    "maven.clj"
    106]
   [clojure.tools.deps.extensions.maven$eval1707$fn__1708
    invoke
    "maven.clj"
    146]
   [clojure.lang.MultiFn invoke "MultiFn.java" 244]
   [clojure.tools.deps$expand_deps$children_task__1266$fn__1268$fn__1269
    invoke
    "deps.clj"
    416]
   [clojure.lang.AFn applyToHelper "AFn.java" 152]
   [clojure.lang.AFn applyTo "AFn.java" 144]
   [clojure.core$apply invokeStatic "core.clj" 667]
   [clojure.core$with_bindings_STAR_ invokeStatic "core.clj" 1990]
   [clojure.core$with_bindings_STAR_ doInvoke "core.clj" 1990]
   [clojure.lang.RestFn invoke "RestFn.java" 428]
   [clojure.lang.AFn applyToHelper "AFn.java" 156]
   [clojure.lang.RestFn applyTo "RestFn.java" 135]
   [clojure.core$apply invokeStatic "core.clj" 671]
   [clojure.core$bound_fn_STAR_$fn__5837 doInvoke "core.clj" 2020]
   [clojure.lang.RestFn invoke "RestFn.java" 400]
   [clojure.lang.AFn call "AFn.java" 18]
   [java.util.concurrent.FutureTask run "FutureTask.java" 264]
   [java.util.concurrent.ThreadPoolExecutor
    runWorker
    "ThreadPoolExecutor.java"
    1136]
   [java.util.concurrent.ThreadPoolExecutor$Worker
    run
    "ThreadPoolExecutor.java"
    635]
   [java.lang.Thread run "Thread.java" 833]],
  :cause
  "C:\\Users\\ikappaki\\.m2\\repository\\io\\opentelemetry\\opentelemetry-exporter-common\\1.54.1\\_remote.repositories.12805229861750152054.tmp -> C:\\Users\\ikappaki\\.m2\\repository\\io\\opentelemetry\\opentelemetry-exporter-common\\1.54.1\\_remote.repositories"}}


```

- [ ] I added a entry in changelog under unreleased section.
