### PR TITLE
Add git worktree support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix deepseek reasoning with openai-chat API #228
 - Support `~` in dynamic string parser.
 - Support removing nullable values from LLM request body if the value in extraPayload is null. #232
+- Add git worktree support: automatically detect and use git repository root as workspace folder when not explicitly provided.
 
 ## 0.86.0
 

--- a/src/eca/git.clj
+++ b/src/eca/git.clj
@@ -1,0 +1,48 @@
+(ns eca.git
+  (:require
+   [clojure.java.shell :as shell]
+   [clojure.string :as string]
+   [eca.logger :as logger]))
+
+(set! *warn-on-reflection* true)
+
+(defn ^:private git-command
+  "Execute a git command and return the trimmed output if successful."
+  [& args]
+  (try
+    (let [{:keys [out exit err]} (apply shell/sh "git" args)]
+      (when (= 0 exit)
+        (string/trim out))
+      (when-not (= 0 exit)
+        (logger/debug "Git command failed:" args "Error:" err))
+      (when (= 0 exit)
+        (string/trim out)))
+    (catch Exception e
+      (logger/debug "Git command exception:" (ex-message e))
+      nil)))
+
+(defn root
+  "Get the top-level directory of the current git repository or worktree.
+  Returns the absolute path to the working directory root, which is the correct
+  location for finding .eca config files in both regular repos and worktrees."
+  []
+  (git-command "rev-parse" "--show-toplevel"))
+
+(defn in-worktree?
+  "Check if the current directory is in a git worktree (not the main working tree)."
+  []
+  (when-let [git-dir (git-command "rev-parse" "--git-dir")]
+    (and git-dir
+         (string/includes? git-dir "/worktrees/"))))
+
+(defn main-repo-root
+  "Get the root of the main repository (not the worktree).
+  This is useful if you need to access the main repo's directory.
+  Returns nil if not in a git repository or if already in the main repo."
+  []
+  (when-let [common-dir (git-command "rev-parse" "--git-common-dir")]
+    (when (not= common-dir ".git")
+      ;; Common dir points to the main .git directory
+      ;; Get the parent directory of .git and then get its toplevel
+      (let [parent-dir (.getParent (clojure.java.io/file common-dir))]
+        (git-command "-C" parent-dir "rev-parse" "--show-toplevel")))))

--- a/test/eca/git_test.clj
+++ b/test/eca/git_test.clj
@@ -1,0 +1,90 @@
+(ns eca.git-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as string]
+   [clojure.test :refer [deftest is testing]]
+   [eca.git :as git]))
+
+(set! *warn-on-reflection* true)
+
+(deftest root-test
+  (testing "git root returns a path when in a git repository"
+    (let [result (git/root)]
+      ;; Should return a non-empty string path or nil
+      (is (or (nil? result)
+              (and (string? result)
+                   (not (empty? result)))))
+      
+      ;; If we have a root, it should be an absolute path
+      (when result
+        (is (.isAbsolute (io/file result)))))))
+
+(deftest in-worktree-test
+  (testing "in-worktree? returns a boolean"
+    (let [result (git/in-worktree?)]
+      (is (or (true? result)
+              (false? result)
+              (nil? result)))))
+  
+  (testing "correctly detects worktree by checking git-dir"
+    ;; If we're in a worktree, git-dir should contain /worktrees/
+    (when (git/in-worktree?)
+      (let [{:keys [out exit]} (shell/sh "git" "rev-parse" "--git-dir")]
+        (when (= 0 exit)
+          (is (string/includes? out "worktrees")))))))
+
+(deftest main-repo-root-test
+  (testing "main-repo-root returns a path or nil"
+    (let [result (git/main-repo-root)]
+      (is (or (nil? result)
+              (and (string? result)
+                   (not (empty? result)))))
+      
+      ;; If we have a main repo root, it should be absolute
+      (when result
+        (is (.isAbsolute (io/file result)))))))
+
+(deftest integration-test
+  (testing "git functions work together logically"
+    (let [root (git/root)]
+      (if root
+        (do
+          ;; If we have a git root, we're in a git repo
+          (is (string? root))
+          (is (.exists (io/file root)))
+          
+          ;; If we're in a worktree, behavior should be consistent
+          (if (git/in-worktree?)
+            (testing "in a worktree"
+              (let [main-root (git/main-repo-root)]
+                ;; Main repo root should exist
+                (is (some? main-root))
+                (when main-root
+                  ;; Main root and worktree root should be different
+                  (is (not= root main-root))
+                  ;; Both should exist
+                  (is (.exists (io/file main-root))))))
+            
+            (testing "in main repo (not a worktree)"
+              ;; In main repo, main-repo-root might be nil or same as root
+              (let [main-root (git/main-repo-root)]
+                (is (or (nil? main-root)
+                        (= root main-root)))))))
+        ;; If not in a git repo, verify that git/root returns nil
+        (is (nil? root))))))
+
+(deftest worktree-config-discovery-test
+  (testing "git root is suitable for .eca config discovery"
+    (let [root (git/root)]
+      (if root
+        ;; The root should be a directory where .eca config could exist
+        (let [eca-dir (io/file root ".eca")]
+          ;; We don't test if .eca exists, just that the parent dir is valid
+          (is (.isDirectory (io/file root)))
+          
+          ;; If .eca exists, it should be in the worktree root (not main repo)
+          (when (.exists eca-dir)
+            (is (.isDirectory eca-dir))))
+        ;; If not in a git repo, verify that git/root returns nil
+        (is (nil? root))))))

--- a/test/eca/llm_util_test.clj
+++ b/test/eca/llm_util_test.clj
@@ -132,7 +132,8 @@
         (spit temp-path (str "machine api.anthropic.com\nlogin work\npassword sk-ant-work-key\n\n"
                              "machine api.anthropic.com\nlogin personal\npassword sk-ant-personal-key\n"))
 
-        (with-redefs [secrets/credential-file-paths (constantly [temp-path])]
+        (with-redefs [secrets/credential-file-paths (constantly [temp-path])
+                      config/get-env (constantly nil)]
           ;; Test with specific login
           (let [config {:providers
                         {"anthropic" {:keyRc "work@api.anthropic.com"}}}


### PR DESCRIPTION
- [x] I added a entry in changelog under unreleased section.

<!-- Message of single commit: -->

Add git worktree support for workspace and config discovery

- Add new eca.git namespace with utilities for detecting git roots and worktrees
- Update config loading to fall back to git root when no workspace folders provided
- Update initialize handler to use git root as workspace folder fallback
- Fix test isolation by mocking config/get-env in provider-api-key test
- Add comprehensive tests for git utilities and config fallback behavior

Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>