### PR TITLE
 Fix OpenAI chat tool_call id handling in streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix openai-chat tool call + support for Mistral API #233
 
 ## 0.87.1
 

--- a/src/eca/features/prompt.clj
+++ b/src/eca/features/prompt.clj
@@ -80,7 +80,6 @@
                          "")))
     ""
     refined-contexts)
-   ;; TODO - should be refined contexts?
    (when startup-ctx
      (str "\n<additionalContext from=\"chatStart\">\n" startup-ctx "\n</additionalContext>\n\n"))
    "</contexts>"))


### PR DESCRIPTION
Preserves provider-generated tool_calls[].id in OpenAI-compatible Chat Completions and stabilizes streaming tool-call accumulation by index/id, ensuring tool-call UI/state transitions remain correct across providers.


- [x] I added a entry in changelog under unreleased section.
