### PR TITLE
Fix trigger-post-tool-call-hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix tokens not renewing between tool calls. #258
 - Fix diff correct numbers in added/removed. #259
+- Fix post tool call hook trigger
 
 ## 0.90.0
 

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -382,11 +382,11 @@
 
    [:executing :execution-end]
    {:status :cleanup
-    :actions [:save-execution-result :deliver-future-cleanup-completed :send-toolCalled :log-metrics :send-progress]}
+    :actions [:save-execution-result :deliver-future-cleanup-completed :send-toolCalled :log-metrics :send-progress :trigger-post-tool-call-hook]}
 
    [:cleanup :cleanup-finished]
    {:status :completed
-    :actions [:destroy-all-resources :remove-all-resources :remove-all-promises :remove-future :trigger-post-tool-call-hook]}
+    :actions [:destroy-all-resources :remove-all-resources :remove-all-promises :remove-future]}
 
    [:executing :resources-created]
    {:status :executing
@@ -402,7 +402,7 @@
 
    [:stopping :stop-attempted]
    {:status :cleanup
-    :actions [:save-execution-result :deliver-future-cleanup-completed :send-toolCallRejected]}
+    :actions [:save-execution-result :deliver-future-cleanup-completed :send-toolCallRejected :trigger-post-tool-call-hook]}
 
    ;; And now all the :stop-requested transitions
 

--- a/test/eca/features/chat_tool_call_state_test.clj
+++ b/test/eca/features/chat_tool_call_state_test.clj
@@ -472,7 +472,7 @@
               result (#'f.chat/transition-tool-call! db* chat-ctx tool-call-id :execution-end result-data)]
 
           (is (match? {:status :cleanup
-                       :actions [:save-execution-result :deliver-future-cleanup-completed :send-toolCalled :log-metrics :send-progress]}
+                       :actions [:save-execution-result :deliver-future-cleanup-completed :send-toolCalled :log-metrics :send-progress :trigger-post-tool-call-hook]}
                       result)
               "Expected transition to :cleanup with send toolCalled and record metrics actions")
 
@@ -543,7 +543,7 @@
                 "Expected transition from :executing to :stopping with relevant actions"))
           (let [result (#'f.chat/transition-tool-call! db* chat-ctx "tool-executing" :stop-attempted)]
             (is (match? {:status :cleanup
-                         :actions [:save-execution-result :deliver-future-cleanup-completed :send-toolCallRejected]}
+                         :actions [:save-execution-result :deliver-future-cleanup-completed :send-toolCallRejected :trigger-post-tool-call-hook]}
                         result)
                 "Expected transition from :stopping to :cleanup with relevant actions"))))
 
@@ -907,7 +907,7 @@
               result (#'f.chat/transition-tool-call! db* chat-ctx tool-call-id :execution-end error-result)]
 
           (is (match? {:status :cleanup
-                       :actions [:save-execution-result :deliver-future-cleanup-completed :send-toolCalled :log-metrics :send-progress]}
+                       :actions [:save-execution-result :deliver-future-cleanup-completed :send-toolCalled :log-metrics :send-progress :trigger-post-tool-call-hook]}
                       result)
               "Expected transition to :cleanup with send toolCalled and record metrics actions")
 


### PR DESCRIPTION
- Post tool call hook was triggered when all tool calls in one turn have been approved / rejected
- Now it runs for each tool call right after the approval / rejection


- [x] I added a entry in changelog under unreleased section.
