### PR TITLE
Add configurable reasoning preservation for openai completions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -694,7 +694,7 @@ To configure, add your OTLP collector config via `:otlp` map following [otlp aut
             models: {[key: string]: {
               modelName?: string;
               extraPayload?: {[key: string]: any};
-              keepHistoryReasoning?: boolean;
+              reasoningHistory?: "all" | "turn" | "off";
             }};
         }};
         defaultModel?: string;

--- a/docs/models.md
+++ b/docs/models.md
@@ -73,7 +73,7 @@ Schema:
 | `models`                              | map     | Key: model name, value: its config                                                                           | Yes      |
 | `models <model> extraPayload`         | map     | Extra payload sent in body to LLM                                                                            | No       |
 | `models <model> modelName`            | string  | Override model name, useful to have multiple models with different configs and names that use same LLM model | No       |
-| `models <model> keepHistoryReasoning` | boolean | Keep `reason` messages in conversation history. Default: `false`                                             | No       |
+| `models <model> reasoningHistory`     | string  | Controls reasoning in conversation history: `"all"` (default), `"turn"`, or `"off"`                          | No       |
 | `fetchModels`                         | boolean | Enable automatic model discovery from `/models` endpoint (OpenAI-compatible providers)                       | No       |
 
 _* url and key will be searched as envs `<provider>_API_URL` and `<provider>_API_KEY`, they require the env to be found or config to work._
@@ -121,32 +121,19 @@ Examples:
 
     This way both will use gpt-5 model but one will override the reasoning to be high instead of the default.
 
-=== "History reasoning"
-	`keepHistoryReasoning` - Determines whether the model's internal reasoning chain is persisted in the conversation history for subsequent turns.
+=== "Reasoning in conversation history"
+	`reasoningHistory` - Controls whether and how the model's reasoning (thinking blocks, reasoning_content) is included in conversation history sent to the model.
+	This **only applies** to `openai_chat` API and it controls both tag-based thinking and the preservation of  `reasoning_content`.
 
-	- **Standard Behavior**: Most models expect reasoning blocks (e.g., `<think>` tags or `reasoning_content`) to be removed in subsequent requests to save tokens and avoid bias.
-	- **Usage**: Enable this for models that explicitly support "preserved thinking," or if you want to experiment with letting the model see its previous thought process (with XML-based reasoning).
-	- **Example**: See [GLM-4.7 with Preserved thinking](https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking).
+	**Available modes:**
 
-    ```javascript title="~/.config/eca/config.json"
-    {
-      "providers": {
-        "z-ai": {
-          "api": "openai-chat",
-          "url": "https://api.z.ai/api/paas/v4/",
-          "key": "your-api-key",
-          "models": {
-            "GLM-4.7": {
-              "keepHistoryReasoning": true,  // Preserves reasoning
-              "extraPayload": {"clear_thinking": false} // Preserved thinking (see https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking)
-			  }
-          }
-        }
-      }
-    }
-    ```
+	- **`"all"`** (default, safe choice) - Send all reasoning blocks back to the model. The model can see its full chain of thought from previous turns. This is the safest option.
+	- **`"turn"`** - Send only reasoning from the current conversation turn (after the last user message). Previous reasoning is discarded before sending to the API.
+	- **`"off"`** - Never send reasoning blocks to the model. All reasoning is discarded before API calls.
 
-    Default: `false`.
+	**Note:** Reasoning is always shown to you in the UI and stored in chat history—this setting only controls what gets sent to the model in API requests.
+
+    Default: `"all"`.
 
 === "Dynamic model discovery"
 

--- a/integration-test/integration/chat/github_copilot_test.clj
+++ b/integration-test/integration/chat/github_copilot_test.clj
@@ -168,7 +168,7 @@
         (match-content chat-id "system" {:type "progress" :state "finished"})
         (is (match?
              {:input [{:role "user" :content [{:type "input_text" :text "hello!"}]}
-                      {:role "assistant" :content [{:type "output_text" :text "hello there!"}]}
+                      {:role "assistant" :content [{:type "output_text" :text "<think>I should say hello</think>\nhello there!"}]}
                       {:role "user" :content [{:type "input_text" :text "how are you?"}]}]
               :instructions (m/pred string?)}
              (llm.mocks/get-req-body :reasoning-1)))))))

--- a/integration-test/integration/chat/google_test.clj
+++ b/integration-test/integration/chat/google_test.clj
@@ -167,7 +167,7 @@
         (match-content chat-id "system" {:type "progress" :state "finished"})
         (is (match?
              {:input [{:role "user" :content [{:type "input_text" :text "hello!"}]}
-                      {:role "assistant" :content [{:type "output_text" :text "hello there!"}]}
+                      {:role "assistant" :content [{:type "output_text" :text "<thought>I should say hello</thought>\nhello there!"}]}
                       {:role "user" :content [{:type "input_text" :text "how are you?"}]}]
               :instructions (m/pred string?)}
              (llm.mocks/get-req-body :reasoning-1)))))))

--- a/src/eca/config.clj
+++ b/src/eca/config.clj
@@ -336,7 +336,8 @@
   {:kebab-case-key
    [[:providers]]
    :keywordize-val
-   [[:providers :ANY :httpClient]]
+   [[:providers :ANY :httpClient]
+    [:providers :ANY :models :ANY :reasoningHistory]]
    :stringfy-key
    [[:behavior]
     [:providers]

--- a/src/eca/llm_api.clj
+++ b/src/eca/llm_api.clj
@@ -97,6 +97,7 @@
         provider-config (get-in config [:providers provider])
         model-config (get-in provider-config [:models model])
         extra-payload (:extraPayload model-config)
+        reasoning-history (or (:reasoningHistory model-config) :all)
         [auth-type api-key] (llm-util/provider-api-key provider provider-auth config)
         api-url (llm-util/provider-api-url provider config)
         {:keys [handler]} (provider->api-handler provider config)
@@ -123,6 +124,7 @@
           :web-search web-search
           :extra-payload (merge {:parallel_tool_calls true}
                                 extra-payload)
+          :reasoning-history reasoning-history
           :api-url api-url
           :api-key api-key
           :auth-type auth-type}
@@ -157,6 +159,7 @@
           :tools tools
           :extra-payload (merge {:parallel_tool_calls true}
                                 extra-payload)
+          :reasoning-history reasoning-history
           :api-url api-url
           :api-key api-key
           :extra-headers {"openai-intent" "conversation-panel"
@@ -179,6 +182,7 @@
           :tools tools
           :think-tag-start "<thought>"
           :think-tag-end "</thought>"
+          :reasoning-history reasoning-history
           :extra-payload (merge {:parallel_tool_calls false}
                                 (when reason?
                                   {:extra_body {:google {:thinking_config {:include_thoughts true}}}})
@@ -206,7 +210,6 @@
         (let [url-relative-path (:completionUrlRelativePath provider-config)
               think-tag-start (:thinkTagStart provider-config)
               think-tag-end (:thinkTagEnd provider-config)
-              keep-history-reasoning (:keepHistoryReasoning model-config)
               http-client (:httpClient provider-config)]
           (handler
            {:model real-model
@@ -222,7 +225,7 @@
             :url-relative-path url-relative-path
             :think-tag-start think-tag-start
             :think-tag-end think-tag-end
-            :keep-history-reasoning keep-history-reasoning
+            :reasoning-history reasoning-history
             :http-client http-client
             :api-url api-url
             :api-key api-key}

--- a/test/eca/llm_providers/openai_chat_test.clj
+++ b/test/eca/llm_providers/openai_chat_test.clj
@@ -259,7 +259,7 @@
            {:role "assistant" :reasoning_content "Thinking..."}])))))
 
 (deftest prune-history-test
-  (testing "Drops all reason messages before the last user message by default"
+  (testing "reasoningHistory \"turn\" drops all reason messages before the last user message"
     (is (match?
          [{:role "user" :content "Q1"}
           {:role "assistant" :content "A1"}
@@ -273,13 +273,14 @@
            {:role "user" :content "Q2"}
            {:role "reason" :content {:text "r2" :delta-reasoning? true}}
            {:role "assistant" :content "A2"}]
-          false))))
+          :turn))))
 
-  (testing "Preserves reason messages (without :delta-reasoning?) before last user message"
+  (testing "reasoningHistory \"turn\" also drops think-tag reasoning before last user message"
     (is (match?
          [{:role "user" :content "Q1"}
           {:role "assistant" :content "A1"}
           {:role "user" :content "Q2"}
+          {:role "reason" :content {:text "more thinking..."}}
           {:role "assistant" :content "A2"}]
          (#'llm-providers.openai-chat/prune-history
           [{:role "user" :content "Q1"}
@@ -288,9 +289,9 @@
            {:role "user" :content "Q2"}
            {:role "reason" :content {:text "more thinking..."}}
            {:role "assistant" :content "A2"}]
-          false))))
+          :turn))))
 
-  (testing "Preserves all reasoning when keep-history-reasoning is true (Bedrock)"
+  (testing "reasoningHistory \"all\" preserves all reasoning"
     (is (match?
          [{:role "user" :content "Q1"}
           {:role "reason" :content {:text "r1"}}
@@ -305,12 +306,35 @@
            {:role "user" :content "Q2"}
            {:role "reason" :content {:text "r2"}}
            {:role "assistant" :content "A2"}]
-          true))))
+          :all))))
 
-  (testing "No user message leaves list unchanged"
+  (testing "reasoningHistory \"off\" removes all reasoning messages"
+    (is (match?
+         [{:role "user" :content "Q1"}
+          {:role "assistant" :content "A1"}
+          {:role "user" :content "Q2"}
+          {:role "assistant" :content "A2"}]
+         (#'llm-providers.openai-chat/prune-history
+          [{:role "user" :content "Q1"}
+           {:role "reason" :content {:text "r1" :delta-reasoning? true}}
+           {:role "assistant" :content "A1"}
+           {:role "user" :content "Q2"}
+           {:role "reason" :content {:text "r2"}}
+           {:role "assistant" :content "A2"}]
+          :off))))
+
+  (testing "No user message - reasoningHistory \"turn\" leaves list unchanged"
     (let [msgs [{:role "assistant" :content "A"}
                 {:role "reason" :content {:text "r"}}]]
-      (is (= msgs (#'llm-providers.openai-chat/prune-history msgs false))))))
+      (is (= msgs (#'llm-providers.openai-chat/prune-history msgs :turn)))))
+
+  (testing "No user message - reasoningHistory \"off\" removes reason"
+    (is (match?
+         [{:role "assistant" :content "A"}]
+         (#'llm-providers.openai-chat/prune-history
+          [{:role "assistant" :content "A"}
+           {:role "reason" :content {:text "r"}}]
+          :off)))))
 
 (deftest valid-message-test
   (testing "Tool messages are always kept"


### PR DESCRIPTION
Discard reasoning before last user message (based on OpenAI SDK). 
Model-level config enables preservation (e.g. GLM-4.7 with preserved thinking).

Changes:
- prune-history: add keep-history-reasoning parameter
- Tests: cover both pruning and preservation
- Docs: add keepHistoryReasoning to model schema


- [x] I added a entry in changelog under unreleased section.

@ericdallo Subjectively, the behavior seems better now. Since it's difficult to evaluate, I went through the OpenAI SDK with Opencode via Opus and it found that they discard it as well. And I couldn't find any documentation that would suggest we should do otherwise by default. 