### PR TITLE
Fix openai-chat tool_call_id handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+ - Fix openai-chat tool calls freezing when providers emit duplicate/invalid tool_calls[].id values.
+
 ## 0.98.0
 
 - Add support for adding `extraHeaders` to models configuration.


### PR DESCRIPTION
Some OpenAI-chat compatible providers emit tool_calls[].id that can be duplicated or contain whitespace. Using that value as our internal tool-call identity can corrupt the tool-call state machine and stall the chat.

Generate an internal UUID (:id) for each tool call and preserve the provider ID in :llm-tool-call-id. When sending tool calls/results back to the API, echo :llm-tool-call-id as tool_calls[].id/tool_call_id. Ignore non-stream tool calls with invalid JSON arguments.


- [x] I added a entry in changelog under unreleased section.
