### PR TITLE
Fix NullPointerException when model is nil in chat and completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix NullPointerException when model is nil in chat and completion
+
 ## 0.101.0
 
 - Foreground subagents support! #160

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -1495,7 +1495,7 @@
         user-messages [{:role "user" :content (vec (concat [{:type :text :text message}]
                                                            expanded-prompt-contexts
                                                            image-contents))}]
-        [provider model] (string/split full-model #"/" 2)
+        [provider model] (llm-util/parse-model full-model)
         chat-ctx (merge base-chat-ctx
                         {:instructions instructions
                          :user-messages user-messages

--- a/src/eca/features/rewrite.clj
+++ b/src/eca/features/rewrite.clj
@@ -5,6 +5,7 @@
    [eca.features.prompt :as f.prompt]
    [eca.features.tools :as f.tools]
    [eca.llm-api :as llm-api]
+   [eca.llm-util :as llm-util]
    [eca.logger :as logger]
    [eca.messenger :as messenger]
    [eca.shared :refer [future*]]))
@@ -26,7 +27,7 @@
                        (llm-api/default-model db config))
         _ (when-not full-model
             (throw (ex-info llm-api/no-available-model-error-msg {})))
-        [provider model] (string/split full-model #"/" 2)
+        [provider model] (llm-util/parse-model full-model)
         model-capabilities (get-in db [:models full-model])
         full-text (when path (llm-api/refine-file-context path nil))
         start-time (System/currentTimeMillis)

--- a/src/eca/llm_util.clj
+++ b/src/eca/llm_util.clj
@@ -12,6 +12,12 @@
 
 (set! *warn-on-reflection* true)
 
+(defn parse-model
+  "Splits a full-model string like \"provider/model\" into [provider model].
+  Returns nil when full-model is nil."
+  [full-model]
+  (some-> full-model (string/split #"/" 2)))
+
 (defn find-last-msg-idx
   "Returns the index of the last message in `msgs` for which `(pred msg)` is true."
   [pred msgs]

--- a/src/eca/models.clj
+++ b/src/eca/models.clj
@@ -111,7 +111,7 @@
    models-dev-data))
 
 (defn ^:private auth-valid? [full-model db config]
-  (let [[provider _model] (string/split full-model #"/" 2)]
+  (let [[provider _model] (llm-util/parse-model full-model)]
     (or (not (get-in config [:providers provider :requiresAuth?] false))
         (and (llm-util/provider-api-url provider config)
              (llm-util/provider-api-key provider (get-in db [:auth provider]) config)))))

--- a/test/eca/features/completion_test.clj
+++ b/test/eca/features/completion_test.clj
@@ -1,7 +1,8 @@
 (ns eca.features.completion-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [eca.features.completion :as f.completion]))
+   [eca.features.completion :as f.completion]
+   [eca.test-helper :as h]))
 
 (deftest normalize-code-result-test
   (testing "triple backticks with language label"
@@ -23,3 +24,19 @@
   (testing "preserve leading spaces when no fences"
     (is (= "    (println \"indented\")"
            (#'f.completion/normalize-code-result "    (println \"indented\")")))))
+
+(deftest complete-with-nil-model-test
+  (testing "Returns clean error when no completion model is configured (nil full-model)"
+    (h/reset-components!)
+    (h/config! {:env "test"})
+    (let [result (f.completion/complete
+                  {:doc-text "(defn foo [] 1)"
+                   :doc-version 1
+                   :position {:line 1 :character 16}}
+                  (h/db*)
+                  (h/config)
+                  (h/messenger)
+                  (h/metrics))]
+      (is (some? (:error result)) "Should return an error map")
+      (is (= :warning (get-in result [:error :type])))
+      (is (string? (get-in result [:error :message]))))))


### PR DESCRIPTION
**Note: I am not a closure developer nor did I write this claude did, but this seemed like a reasonable change.**

I wanted to try out eca on emacs, but from a clean installation using mise eca (which doesn’t seem to matter), I encountered [eca-chat-error.txt](https://github.com/user-attachments/files/25317683/eca-chat-error.txt) and [eca-chat-error-log.txt](https://github.com/user-attachments/files/25317682/eca-chat-error-log.txt).

After making these changes, I no longer encounter this issue with a locally built native-cli binary: [eca-chat.txt](https://github.com/user-attachments/files/25317681/eca-chat.txt)


- Extract parse-model utility to llm-util with nil safety via some->, replacing inline string/split calls across chat.clj, completion.clj, rewrite.clj, and models.clj.
- Add early return in completion when no model is configured. Add tests for nil model scenarios.


- [X] I added a entry in changelog under unreleased section.
- [] This is not an AI slop.