### PR TITLE
Fix directory_tree returning empty results for paths outside workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix `directory_tree` returning empty results for paths outside workspace folders.
 - Fix anthropic "invalid_request_error" that may happen when doing server web-search + thinking, causing errors in chat.
 
 ## 0.101.1

--- a/src/eca/features/tools/filesystem.clj
+++ b/src/eca/features/tools/filesystem.clj
@@ -37,7 +37,9 @@
               lines* (atom [(str @path)])
               root-filename (path->root-filename db @path)
               all-paths (fs/glob @path "**")
-              allowed-files (set (f.index/filter-allowed all-paths root-filename config))
+              allowed-files (if root-filename
+                              (set (f.index/filter-allowed all-paths root-filename config))
+                              (set (map fs/canonicalize all-paths)))
               walk (fn walk [dir depth]
                      (let [files (fs/list-dir dir)
                            names (->> files


### PR DESCRIPTION
directory_tree filtered all files when called on paths outside workspace folders. path->root-filename returned nil, causing git-ls-files to run in the wrong directory and the gitignore filter to reject every file.

Skip gitignore filtering when the target path is not within any workspace folder, restoring pre-42712c32 behavior for this case.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
