### PR TITLE
Allow manually starting disabled MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow manually starting MCP servers even when configured with `disabled: true` (still not auto-started).
+
 ## 0.109.5
 
 - Fix clear messages to reset usage tokens as well.

--- a/src/eca/features/tools/mcp.clj
+++ b/src/eca/features/tools/mcp.clj
@@ -401,9 +401,9 @@
 
 (defn start-server! [name db* config metrics {:keys [on-server-updated]}]
   (when-let [server-config (get-in config [:mcpServers name])]
-    (if (get server-config :disabled false)
-      (logger/warn logger-tag (format "MCP server %s is disabled and cannot be started" name))
-      (initialize-server! name db* config metrics on-server-updated))))
+    (when (get server-config :disabled false)
+      (logger/info logger-tag (format "Starting MCP server %s from manual request despite :disabled=true" name)))
+    (initialize-server! name db* config metrics on-server-updated)))
 
 (defn all-tools [db]
   (into []


### PR DESCRIPTION
- Allow manually starting MCP servers even when configured with `disabled: true` (still not auto-started).


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
