### PR TITLE
Fix extra-payload destructuring in Ollama provider

### DIFF
--- a/src/eca/llm_providers/ollama.clj
+++ b/src/eca/llm_providers/ollama.clj
@@ -118,9 +118,9 @@
              }))
         messages))
 
-(defn chat! [{:keys [model user-messages reason? instructions api-url past-messages tools extra-headers]}
+(defn chat! [{:keys [model user-messages reason? instructions api-url past-messages tools extra-headers extra-payload]}
              {:keys [on-message-received on-error on-prepare-tool-call on-tools-called
-                     on-reason extra-payload] :as callbacks}]
+                     on-reason] :as callbacks}]
   (let [messages (concat
                   (normalize-messages (concat [{:role "system" :content instructions}] past-messages))
                   (normalize-messages user-messages))


### PR DESCRIPTION
## Summary

`extra-payload` was destructured from the callbacks map (arg 2) in `ollama/chat!`, but `prompt!` passes it in the opts map (arg 1). This meant `extraPayload` from model config was silently ignored for Ollama requests.

All other providers (openai, anthropic, google, github-copilot) receive `extra-payload` in the opts map, consistent with how `prompt!` passes it at line 303 of `llm_api.clj`.

## The bug

```clojure
;; prompt! passes extra-payload in arg 1 (opts):
(handler
 {:api-url api-url
  :extra-payload extra-payload  ;; <-- here, in opts
  ...}
 callbacks)

;; But ollama/chat! destructures it from arg 2 (callbacks):
(defn chat! [{:keys [model ...]}                          ;; arg 1 - no extra-payload
             {:keys [... extra-payload] :as callbacks}]   ;; arg 2 - reads it here
```

## The fix

Move `extra-payload` from the callbacks destructuring to the opts destructuring in `ollama/chat!`.

## Impact

Without this fix, any `extraPayload` set via ECA model config (e.g., `{:options {:num_ctx 16384}}`) is silently dropped for Ollama requests. This causes Ollama to fall back to VRAM-auto-detected defaults, which on high-VRAM machines (e.g., M1 Max 48GB) allocates a 262K token KV cache — making even trivial prompts take 60-112 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)