### PR TITLE
docs(providers): add Mistral to the provider examples section

### DIFF
--- a/docs/config/models.md
+++ b/docs/config/models.md
@@ -415,7 +415,27 @@ When a retry rule matches, the chat shows a progress message like:
       }
     }
     ```
-    
+
+=== "Mistral"
+
+    The property `max_completion_token` is set to `null`, because Mistral does not support it.
+
+    More details in the [Mistral API docs](https://docs.mistral.ai/api).
+
+    ```javascript title="~/.config/eca/config.json"
+    {
+      "providers": {
+        "mistral": {
+          "api": "openai-chat",
+          "url": "https://api.mistral.ai/v1",
+          "key": "your-api-key",
+          "models": {
+            "mistral-medium": {"extraPayload": { "max_completion_tokens": null}}
+          }
+        }
+    }
+    ```
+
 === "Moonshot"
 
     ```javascript title="~/.config/eca/config.json"


### PR DESCRIPTION
Adding the Mistral provider in the examples section, useful for Eca users trying it out. The example shows how to set up the `url` and the `extraPayload` in specific.

- [ ] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
