### PR TITLE
Fix NPE in query-commands when command name or description is nil

### DIFF
--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -901,8 +901,8 @@
         commands (f.commands/all-commands @db* config)
         commands (if (string/blank? query)
                    commands
-                   (filter #(or (string/includes? (string/lower-case (:name %)) query)
-                                (string/includes? (string/lower-case (:description %)) query))
+                   (filter #(or (some-> (:name %) string/lower-case (string/includes? query))
+                                (some-> (:description %) string/lower-case (string/includes? query)))
                            commands))]
     {:chat-id chat-id
      :commands commands}))


### PR DESCRIPTION
## Summary
- `query-commands` in `chat.clj` calls `clojure.string/lower-case` on `:name` and `:description` fields without nil guards
- MCP servers can return prompts without a `description` field, causing a `NullPointerException` when the user opens the `/` command menu, crashing the chat session
- Uses `some->` to short-circuit on nil values instead of throwing

## Stack trace (before fix)
```
Exception in thread "async-mixed-2" java.lang.NullPointerException
    at clojure.string$lower_case.invokeStatic(string.clj:213)
    at eca.features.chat$query_commands$fn__13294.invoke(chat.clj:905)
    at clojure.core$filter$fn__5983.invoke(core.clj:2834)
    ...
```

## Test plan
- [x] Built debug CLI with fix (`bb debug-cli`)
- [x] Tested locally in Emacs with 6 MCP servers configured — `/` menu works without crash