### PR TITLE
Fix issue with dynamically specifying the subagent model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Show the selected `variant` in `spawn_agent` subagent details and harden restrictions regarding the use of the optional model in sub-agent. #369
 
 - Fix MCP OAuth browser not opening on Windows by using `cmd /c start` instead of `java.awt.Desktop`, which is unavailable in the native image.
 
@@ -32,7 +33,7 @@
 ## 0.116.5
 
 - Add `/remote` command to display connection URL, password and setup guide. Password is no longer shown in logs or welcome message.
-- Improve server port binding for remote. 
+- Improve server port binding for remote.
 
 ## 0.116.4
 
@@ -160,7 +161,7 @@
 
 - Fix MCP OAuth client registration failing for servers that require Content-Type header
 - Prevent MCP servers from getting stuck at "starting" when OAuth or other initialization errors occur.
-- Fix GitHub Copilot premium request overconsumption: 
+- Fix GitHub Copilot premium request overconsumption:
   - Chat titles LLM request don't spend premium requests.
   - Subagents now use same premium request of primary agent.
   - gpt-5.3-codex and gpt-5.4 now spend way less premium requests.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1087,6 +1087,11 @@ interface SubagentDetails {
     model: string;
 
     /**
+     * The variant this subagent is using, when one is explicitly selected.
+     */
+    variant?: string;
+
+    /**
      * The name of the agent being spawned.
      */
     agentName: string;

--- a/resources/prompts/tools/spawn_agent.md
+++ b/resources/prompts/tools/spawn_agent.md
@@ -1,18 +1,13 @@
-Spawn a new agent to handle multistep tasks in isolated context.
+Spawn an isolated sub-agent to handle complex, multi-step tasks without polluting your current context.
 
-The agent runs independently with its own conversation history and returns a summary of its findings/actions.
-Use this for:
-- Codebase exploration without polluting your context
-- Focused research on specific areas
-- Delegating specialized tasks (review, analysis, etc.)
+Use for: Codebase exploration, codebase editing and refactoring, focused research, or delegating specialized tasks.
+Proactive use: If the specific agent's description suggests proactive use, use it whenever the task complexity justifies delegation.
+Restrictions: Avoid sub-agents for simple tasks, file reading, or basic lookups. Delegate ONLY if the task is complex, requires multi-step processing, or benefits from summarization and token saving.
+Agent Limits: Sub-agents cannot spawn other agents (no nesting) and have access only to their configured tools.
 
-The spawned agent:
-- Has access only to its configured tools
-- Cannot spawn other agents (no nesting)
-- Must return a summary when complete
-
-Usage notes:
-- Your prompt should contain a highly detailed task description for the agent to perform autonomously and you should specify exactly what information the agent should return back to you in its final message.
-- Clearly tell the agent whether you expect it to write code or just to do research and how to verify its work if possible.
-- If the agent description suggests proactive use, use it whenever the task complexity justifies delegation.
-- Avoid sub-agents for simple tasks, file reading, or basic lookups. Delegate only if the task is complex, requires multi-step processing, or benefits from summarization and token saving.
+Strict rules for arguments:
+- 'task': Provide a highly detailed prompt. Explicitly state whether it should write/edit code or just research, how to verify its work, and exactly what specific information it must return to you.
+- 'activity': Must be a concise 3-4 word label for the UI (e.g., "exploring codebase", "refactoring module").
+- 'model' & 'variant': - Only include these keys if the user explicitly requests a specific model or variant. Otherwise, the agent defaults to its default configuration.
+  - If the user did not ask for a model, OMIT the `model` key entirely. Never send an empty string.
+  - If the user did not ask for a variant, OMIT the `variant` key entirely. Never send an empty string.

--- a/src/eca/features/tools/agent.clj
+++ b/src/eca/features/tools/agent.clj
@@ -55,7 +55,7 @@
 
 (defn ^:private send-step-progress!
   "Send a toolCallRunning notification with current step progress to the parent chat."
-  [messenger chat-id tool-call-id agent-name activity subagent-chat-id step max-steps model arguments]
+  [messenger chat-id tool-call-id agent-name activity subagent-chat-id step max-steps model variant arguments]
   (messenger/chat-content-received
    messenger
    {:chat-id chat-id
@@ -67,12 +67,13 @@
               :origin "native"
               :summary (format "%s: %s" agent-name activity)
               :arguments arguments
-              :details {:type :subagent
-                        :subagent-chat-id subagent-chat-id
-                        :model model
-                        :agent-name agent-name
-                        :step step
-                        :max-steps max-steps}}}))
+              :details (cond-> {:type :subagent
+                                :subagent-chat-id subagent-chat-id
+                                :model model
+                                :agent-name agent-name
+                                :step step
+                                :max-steps max-steps}
+                         variant (assoc :variant variant))}}))
 
 (defn ^:private stop-subagent-chat!
   "Stop a running subagent chat silently (parent already shows 'Prompt stopped')."
@@ -150,7 +151,7 @@
         ;; Create subagent chat session using deterministic id based on tool-call-id
         subagent-chat-id (->subagent-chat-id tool-call-id)
 
-        user-model (get arguments "model")
+        user-model (tools.util/normalize-optional-string (get arguments "model"))
         _ (when user-model
             (let [available-models (:models db)]
               (when (and (seq available-models)
@@ -167,7 +168,7 @@
         ;; Variant validation: reject only when the resolved model has configured
         ;; variants and the user-specified one isn't among them. Models with no
         ;; configured variants accept any variant (the LLM API will reject if invalid).
-        user-variant (get arguments "variant")
+        user-variant (tools.util/normalize-optional-string (get arguments "variant"))
         _ (when user-variant
             (let [valid-variants (model-variant-names config subagent-model)]
               (when (and (seq valid-variants)
@@ -224,7 +225,7 @@
                 ;; Send step progress when step advances
                 (when (> current-step last-step)
                   (send-step-progress! messenger chat-id tool-call-id agent-name activity
-                                       subagent-chat-id current-step max-steps-limit subagent-model arguments))
+                                       subagent-chat-id current-step max-steps-limit subagent-model user-variant arguments))
                 (cond
                   ;; Parent chat stopped — propagate stop to subagent
                   (= :stopping (:status (call-state-fn)))
@@ -259,7 +260,7 @@
           (throw e))))))
 
 (defn ^:private build-description
-  "Build tool description with available agents listed."
+  "Build tool description with available agents and models listed."
   [config]
   (let [base-description (tools.util/read-tool-description "spawn_agent")
         agents (all-agents config)
@@ -280,19 +281,17 @@
                    :properties {"agent" {:type "string"
                                          :description "Name of the agent to spawn"}
                                 "task" {:type "string"
-                                        :description "Clear description of what the agent should accomplish"}
+                                        :description "The detailed instructions for the agent"}
                                 "activity" {:type "string"
                                             :description "Concise label (max 3-4 words) shown in the UI while the agent runs, e.g. \"exploring codebase\", \"reviewing changes\", \"analyzing tests\"."}
                                 "model" {:type "string"
-                                         :description (multi-str
-                                                       "If user specified a model to use."
-                                                       "DO NOT pass this arg if user didn't request it."
-                                                       "Known models: "
-                                                       model-names)}
-                                "variant" (cond-> {:type "string"
-                                                   :description (str "Variant (Usually reasoning related) for the subagent, only pass if user specify."
-                                                                     "Available variants are model-dependent; pick the closest match when the user asks informally (e.g. \"high reasoning\" → \"high\").")}
-                                            (seq variant-names) (assoc :enum variant-names))}
+                                         :description (cond-> "Optional model override. Include this key ONLY when the user explicitly asked for a specific model. Otherwise omit the key entirely; never send an empty string."
+                                                        (and (seq model-names) (> (count model-names) 1))
+                                                        (multi-str "One of these models can be used if the user explicitely requests it: " model-names))}
+                                "variant" {:type        "string"
+                                           :description (cond-> "Optional variant override. Include this key ONLY when the user explicitly asked for a specific variant."
+                                                          (seq variant-names) (multi-str "One of these variants can be used if the user requests it: "
+                                                                                         variant-names))}}
                    :required ["agent" "task" "activity"]}
       :handler #'spawn-agent
       :summary-fn (fn [{:keys [args]}]
@@ -304,8 +303,8 @@
 (defmethod tools.util/tool-call-details-before-invocation :spawn_agent
   [_name arguments _server {:keys [db config chat-id tool-call-id]}]
   (let [agent-name (get arguments "agent")
-        user-model (get arguments "model")
-        user-variant (get arguments "variant")
+        user-model (tools.util/normalize-optional-string (get arguments "model"))
+        user-variant (tools.util/normalize-optional-string (get arguments "variant"))
         subagent (when agent-name
                    (get-agent agent-name config))
         parent-model (get-in db [:chats chat-id :model])

--- a/src/eca/features/tools/util.clj
+++ b/src/eca/features/tools/util.clj
@@ -5,6 +5,7 @@
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
    [clojure.string :as string]
+   [clojure.string :as str]
    [eca.cache :as cache]
    [eca.logger :as logger]
    [eca.shared :as shared]))
@@ -202,3 +203,7 @@
             (assoc result :contents [{:type :text
                                       :text (str truncated notice)}]))
           result)))))
+
+(defn normalize-optional-string
+  [value]
+  (some-> value str/trim not-empty))

--- a/test/eca/features/tools/agent_test.clj
+++ b/test/eca/features/tools/agent_test.clj
@@ -584,8 +584,7 @@
                                 "task" {:type "string"}
                                 "activity" {:type "string"}
                                 "model" {:type "string"}
-                                "variant" {:type "string"
-                                           :enum ["high" "low" "max" "medium"]}}
+                                "variant" {:type "string"}}
                    :required ["agent" "task" "activity"]}
                   (:parameters tool)))))
 


### PR DESCRIPTION
- show variant in subagent tool details (if available)
- harden restrictions regarding the use of the optional model in sub-agent


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
