### PR TITLE
Refresh auth before each LLM API call, not just at prompt start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Refresh auth token before each LLM API call, preventing stale tokens during long-running tool calls.
+
 ## 0.124.5
 
 - Fix Github Enterprise models fetch. #402

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -441,10 +441,9 @@
                           :content [{:type :text :text steer-msg}]
                           :content-id content-id}]
         (add-to-history! user-message)
-        (lifecycle/send-content! chat-ctx :user
-          {:type :text
-           :content-id content-id
-           :text (str steer-msg "\n")})))))
+        (lifecycle/send-content! chat-ctx :user {:type :text
+                                                 :content-id content-id
+                                                 :text (str steer-msg "\n")})))))
 
 (defn ^:private prompt-messages!
   "Send user messages to LLM with hook processing.
@@ -508,7 +507,7 @@
       (swap! db* assoc-in [:chats chat-id :prompt-id] prompt-id)
       (swap! db* assoc-in [:chats chat-id :model] full-model)
       (let [chat-ctx (assoc chat-ctx :prompt-id prompt-id)
-            _ (lifecycle/maybe-renew-auth-token chat-ctx)
+            _ (lifecycle/maybe-renew-auth-token chat-ctx) ;; ensures captured provider-auth fallback is fresh
             db @db*
             model-capabilities (get-in db [:models full-model])
             provider-auth (get-in @db* [:auth provider])
@@ -559,6 +558,11 @@
                 :config  config
                 :tools all-tools
                 :provider-auth provider-auth
+                ;; Renew before each prompt! invocation so long-running chats
+                ;; (spawn_agent, retries) always get a fresh token.
+                :refresh-provider-auth-fn (fn []
+                                            (lifecycle/maybe-renew-auth-token chat-ctx)
+                                            (get-in @db* [:auth provider]))
                 :variant (:variant chat-ctx)
                 :subagent? (some? (get-in @db* [:chats chat-id :subagent]))
                 :cancelled? (fn []
@@ -603,35 +607,36 @@
                                                                          (json/generate-string (:tokens msg)))})
                                                             (lifecycle/finish-chat-prompt! :idle (dissoc chat-ctx :on-finished-side-effect)))
                                          :finish (let [response-text @received-msgs*
-                                                        stopping? (identical? :stopping (get-in @db* [:chats chat-id :status]))]
-                                                  (when-not (string/blank? response-text)
-                                                    (add-to-history! {:role "assistant"
-                                                                      :content [{:type :text :text response-text}]}))
-                                                  (if (and (not stopping?)
-                                                           (not (string/blank? response-text))
-                                                           (or (:premature? msg)
-                                                               (truncated-response? response-text))
-                                                           (not (:auto-continued? chat-ctx))
-                                                           (not (:on-finished-side-effect chat-ctx)))
-                                                    (do
-                                                      (logger/info logger-tag "Truncated or premature response detected, auto-continuing"
-                                                                   {:chat-id chat-id
-                                                                    :premature? (:premature? msg)
-                                                                    :truncated? (truncated-response? response-text)})
-                                                      (lifecycle/send-content! chat-ctx :system
-                                                        {:type :progress :state :running :text "Response interrupted, continuing..."})
-                                                      (swap! db* assoc-in [:chats chat-id :auto-compacting?] true)
-                                                      (lifecycle/finish-chat-prompt! :idle
+                                                       stopping? (identical? :stopping (get-in @db* [:chats chat-id :status]))]
+                                                   (when-not (string/blank? response-text)
+                                                     (add-to-history! {:role "assistant"
+                                                                       :content [{:type :text :text response-text}]}))
+                                                   (if (and (not stopping?)
+                                                            (not (string/blank? response-text))
+                                                            (or (:premature? msg)
+                                                                (truncated-response? response-text))
+                                                            (not (:auto-continued? chat-ctx))
+                                                            (not (:on-finished-side-effect chat-ctx)))
+                                                     (do
+                                                       (logger/info logger-tag "Truncated or premature response detected, auto-continuing"
+                                                                    {:chat-id chat-id
+                                                                     :premature? (:premature? msg)
+                                                                     :truncated? (truncated-response? response-text)})
+                                                       (lifecycle/send-content! chat-ctx :system
+                                                                                {:type :progress :state :running :text "Response interrupted, continuing..."})
+                                                       (swap! db* assoc-in [:chats chat-id :auto-compacting?] true)
+                                                       (lifecycle/finish-chat-prompt!
+                                                        :idle
                                                         (assoc chat-ctx :on-finished-side-effect
-                                                          (fn []
-                                                            (swap! db* update-in [:chats chat-id] dissoc :auto-compacting?)
-                                                            (prompt-messages!
-                                                              [{:role "user"
-                                                                :content [{:type :text
-                                                                           :text "Your previous response was interrupted mid-stream. Continue from where you left off, do not redo completed steps."}]}]
-                                                              :auto-continue
-                                                              (assoc chat-ctx :auto-continued? true))))))
-                                                    (lifecycle/finish-chat-prompt! :idle chat-ctx)))))
+                                                               (fn []
+                                                                 (swap! db* update-in [:chats chat-id] dissoc :auto-compacting?)
+                                                                 (prompt-messages!
+                                                                  [{:role "user"
+                                                                    :content [{:type :text
+                                                                               :text "Your previous response was interrupted mid-stream. Continue from where you left off, do not redo completed steps."}]}]
+                                                                  :auto-continue
+                                                                  (assoc chat-ctx :auto-continued? true))))))
+                                                     (lifecycle/finish-chat-prompt! :idle chat-ctx)))))
                 :on-prepare-tool-call (fn [{:keys [id full-name arguments-text]}]
                                         (lifecycle/assert-chat-not-stopped! chat-ctx)
                                         (let [all-tools (f.tools/all-tools chat-id agent @db* config)
@@ -661,7 +666,7 @@
                                                  (consume-steer-message! chat-id db* chat-ctx add-to-history!)
                                                  {:tools tc-all-tools
                                                   :new-messages (shared/messages-after-last-compact-marker
-                                                                  (get-in @db* [:chats chat-id :messages]))})))))
+                                                                 (get-in @db* [:chats chat-id :messages]))})))))
                                   received-msgs* add-to-history! user-messages)
                 :on-reason (fn [{:keys [status id text external-id delta-reasoning? redacted? data]}]
                              (lifecycle/assert-chat-not-stopped! chat-ctx)
@@ -724,10 +729,10 @@
                                                                                   :summary summary
                                                                                   :progress-text "Searching the web"}))
                                             :input-ready (swap! pending-server-tool-uses* assoc id
-                                                                    {:role "server_tool_use"
-                                                                     :content {:id id
-                                                                               :name name
-                                                                               :input arguments}})
+                                                                {:role "server_tool_use"
+                                                                 :content {:id id
+                                                                           :name name
+                                                                           :input arguments}})
                                             :finished (let [start-time (get @server-tool-times* id)
                                                             total-time-ms (if start-time
                                                                             (- (System/currentTimeMillis) start-time)
@@ -791,18 +796,18 @@
                                       (logger/info logger-tag "Transient error during response, auto-continuing"
                                                    {:chat-id chat-id :error-type error-type})
                                       (lifecycle/send-content! chat-ctx :system
-                                        {:type :progress :state :running :text (str (or message "Connection interrupted") ", continuing...")})
+                                                               {:type :progress :state :running :text (str (or message "Connection interrupted") ", continuing...")})
                                       (swap! db* assoc-in [:chats chat-id :auto-compacting?] true)
                                       (lifecycle/finish-chat-prompt! :idle
-                                        (assoc chat-ctx :on-finished-side-effect
-                                          (fn []
-                                            (swap! db* update-in [:chats chat-id] dissoc :auto-compacting?)
-                                            (prompt-messages!
-                                              [{:role "user"
-                                                :content [{:type :text
-                                                           :text "Your previous response was interrupted mid-stream. Continue from where you left off, do not redo completed steps."}]}]
-                                              :auto-continue
-                                              (assoc chat-ctx :auto-continued? true))))))
+                                                                     (assoc chat-ctx :on-finished-side-effect
+                                                                            (fn []
+                                                                              (swap! db* update-in [:chats chat-id] dissoc :auto-compacting?)
+                                                                              (prompt-messages!
+                                                                               [{:role "user"
+                                                                                 :content [{:type :text
+                                                                                            :text "Your previous response was interrupted mid-stream. Continue from where you left off, do not redo completed steps."}]}]
+                                                                               :auto-continue
+                                                                               (assoc chat-ctx :auto-continued? true))))))
                                     (do
                                       (when-not stopping?
                                         (lifecycle/send-content! chat-ctx :system {:type :text :text (str "\n\n" (or message (str "Error: " (or (ex-message exception) (.getName (class exception))))))}))
@@ -875,7 +880,7 @@
     (catch Exception e
       (logger/error e)
       (lifecycle/send-content! chat-ctx :system {:type :text
-                                                  :text (str "Error: " (ex-message e) "\n\nCheck ECA stderr for more details.")})
+                                                 :text (str "Error: " (ex-message e) "\n\nCheck ECA stderr for more details.")})
       (lifecycle/finish-chat-prompt! :idle (dissoc chat-ctx :on-finished-side-effect)))))
 
 (defn ^:private prompt*
@@ -938,8 +943,8 @@
                                                   agent)))))
         _ (when (seq contexts)
             (lifecycle/send-content! {:messenger messenger :chat-id chat-id} :system {:type :progress
-                                                                                       :state :running
-                                                                                       :text "Parsing given context"}))
+                                                                                      :state :running
+                                                                                      :text "Parsing given context"}))
         refined-contexts (concat
                           (f.context/agents-file-contexts db)
                           (f.context/raw-contexts->refined contexts db))
@@ -1021,7 +1026,7 @@
       (catch Exception e
         (logger/error e)
         (lifecycle/send-content! base-chat-ctx :system {:type :text
-                                                         :text (str "Error: " (ex-message e) "\n\nCheck ECA stderr for more details.")})
+                                                        :text (str "Error: " (ex-message e) "\n\nCheck ECA stderr for more details.")})
         (lifecycle/finish-chat-prompt! :idle (dissoc base-chat-ctx :on-finished-side-effect))
         {:chat-id chat-id
          :model "error"

--- a/src/eca/features/chat/tool_calls.clj
+++ b/src/eca/features/chat/tool_calls.clj
@@ -800,7 +800,16 @@
                                                     :message (.getMessage ^Throwable t)
                                                     :cause (.getCause ^Throwable t)})))))))
             (f.tools.mcp/await-pending-tools-refresh @db* 5000)
-            (let [all-tools (f.tools/all-tools chat-id agent @db* config)]
+            ;; Token can expire during long tool calls (e.g. spawn_agent),
+            ;; so renew before any continuation branch.
+            (lifecycle/maybe-renew-auth-token chat-ctx)
+            (let [all-tools (f.tools/all-tools chat-id agent @db* config)
+                  refreshed-provider-auth (get-in @db* [:auth (:provider chat-ctx)])
+                  [_ refreshed-api-key] (llm-util/provider-api-key (:provider chat-ctx)
+                                                                   refreshed-provider-auth
+                                                                   config)
+                  with-fresh-auth #(some-> % (assoc :fresh-api-key refreshed-api-key
+                                                    :provider-auth refreshed-provider-auth))]
               (if-let [rejection-info @rejected-tool-call-info*]
                 (let [reason-code
                       (if (map? rejection-info) (:code rejection-info) rejection-info)
@@ -813,18 +822,20 @@
                       (do (lifecycle/send-content! chat-ctx :system {:type :text
                                                                      :text (or hook-stop-reason "Tool rejected by hook")})
                           (lifecycle/finish-chat-prompt! :idle chat-ctx) nil)
-                      {:tools all-tools
-                       :new-messages (shared/messages-after-last-compact-marker
-                                      (get-in @db* [:chats chat-id :messages]))})
+                      (with-fresh-auth
+                        {:tools all-tools
+                         :new-messages (shared/messages-after-last-compact-marker
+                                        (get-in @db* [:chats chat-id :messages]))}))
                     (if (get-in @db* [:chats chat-id :subagent])
                       ;; Subagent: user can't provide rejection input directly, so continue
                       ;; the LLM loop with a rejection message letting the subagent adapt
                       (do (add-to-history! {:role "user"
                                             :content [{:type :text
                                                        :text "I rejected one or more tool calls. The tool call was not allowed. Try a different approach to complete the task."}]})
-                          {:tools all-tools
-                           :new-messages (shared/messages-after-last-compact-marker
-                                          (get-in @db* [:chats chat-id :messages]))})
+                          (with-fresh-auth
+                            {:tools all-tools
+                             :new-messages (shared/messages-after-last-compact-marker
+                                            (get-in @db* [:chats chat-id :messages]))}))
                       (do (lifecycle/send-content! chat-ctx :system {:type :text
                                                                      :text "Tell ECA what to do differently for the rejected tool(s)"})
                           (add-to-history! {:role "user"
@@ -832,17 +843,9 @@
                                                        :text "I rejected one or more tool calls with the following reason"}]})
                           (lifecycle/finish-chat-prompt! :idle chat-ctx)
                           nil))))
-                (do
-                  (lifecycle/maybe-renew-auth-token chat-ctx)
-                  (let [provider-auth (get-in @db* [:auth (:provider chat-ctx)])
-                        [_ fresh-api-key] (llm-util/provider-api-key (:provider chat-ctx)
-                                                                     provider-auth
-                                                                     config)
-                        result (if-let [continue-fn (:continue-fn chat-ctx)]
-                                 (continue-fn all-tools user-messages)
-                                 {:tools all-tools
-                                  :new-messages (get-in @db* [:chats chat-id :messages])})]
-                    (when result
-                      (assoc result
-                             :fresh-api-key fresh-api-key
-                             :provider-auth provider-auth))))))))))))
+                (with-fresh-auth
+                  (if-let [continue-fn (:continue-fn chat-ctx)]
+                    (continue-fn all-tools user-messages)
+                    {:tools all-tools
+                     :new-messages (shared/messages-after-last-compact-marker
+                                    (get-in @db* [:chats chat-id :messages]))}))))))))))

--- a/src/eca/features/login.clj
+++ b/src/eca/features/login.clj
@@ -91,7 +91,7 @@
 
 (defn maybe-renew-auth-token! [{:keys [provider on-renewing on-error]} ctx]
   (when-let [expires-at (get-in @(:db* ctx) [:auth provider :expires-at])]
-    ;; Renew 60 seconds before expiration to avoid race between check and request
+    ;; Renew 60s before expiration to avoid race between check and request
     (when (<= (long expires-at) (+ 60 (quot (System/currentTimeMillis) 1000)))
       (when on-renewing
         (on-renewing))

--- a/src/eca/llm_api.clj
+++ b/src/eca/llm_api.clj
@@ -353,7 +353,7 @@
 (defn sync-or-async-prompt!
   [{:keys [provider model model-capabilities instructions user-messages config on-first-response-received
            on-message-received on-error on-prepare-tool-call on-tools-called on-reason on-usage-updated on-server-web-search
-           past-messages tools provider-auth variant cancelled? on-retry subagent?]
+           past-messages tools provider-auth refresh-provider-auth-fn variant cancelled? on-retry subagent?]
     :or {on-first-response-received identity
          on-message-received identity
          on-error identity
@@ -386,6 +386,17 @@
                              (on-error args)))
         provider-config (get-in config [:providers provider])
         retry-rules (:retryRules provider-config)
+        ;; Renew before each prompt! call — token can expire during long tool calls or retries.
+        fresh-provider-auth (fn []
+                              (if refresh-provider-auth-fn
+                                (try
+                                  (or (refresh-provider-auth-fn) provider-auth)
+                                  (catch Exception e
+                                    (logger/warn logger-tag
+                                                 "refresh-provider-auth-fn failed, falling back to captured auth"
+                                                 {:exception (ex-message e)})
+                                    provider-auth))
+                                provider-auth))
         maybe-retry (fn [error-data attempt on-give-up retry-prompt-fn]
                       (let [{error-type :error/type
                              :as classified} (llm-providers.errors/classify-error error-data retry-rules)
@@ -431,7 +442,7 @@
                               :model-capabilities model-capabilities
                               :instructions instructions
                               :tools tools
-                              :provider-auth provider-auth
+                              :provider-auth (fresh-provider-auth)
                               :past-messages past-messages
                               :user-messages user-messages
                               :variant variant
@@ -466,7 +477,7 @@
                 :model-capabilities model-capabilities
                 :instructions instructions
                 :tools tools
-                :provider-auth provider-auth
+                :provider-auth (fresh-provider-auth)
                 :past-messages past-messages
                 :user-messages user-messages
                 :variant variant

--- a/test/eca/features/chat/tool_calls_test.clj
+++ b/test/eca/features/chat/tool_calls_test.clj
@@ -332,3 +332,55 @@
           (is (= expected-provider-auth
                  (:provider-auth result))
               "provider-auth must be returned so providers can reuse refreshed auth metadata"))))))
+
+(deftest on-tools-called!-rejection-returns-fresh-auth-test
+  (testing "rejected subagent path also propagates refreshed auth"
+    ;; Previously rejection branches skipped maybe-renew-auth-token and
+    ;; returned without :fresh-api-key, breaking long-running subagents.
+    (h/reset-components!)
+    (let [chat-id   "test-chat"
+          provider  "github-copilot"
+          renewed-provider-auth {:api-key "fresh-token-after-rejection"
+                                 :expires-at 9999999999}
+          db*       (h/db*)
+          _         (swap! db* #(-> %
+                                    (assoc-in [:auth provider :api-key] "stale-token")
+                                    (assoc-in [:chats chat-id :subagent] {:max-steps nil})
+                                    (assoc-in [:chats chat-id :status] :running)
+                                    (assoc-in [:chats chat-id :messages] [])
+                                    (assoc-in [:chats chat-id :tool-calls "call-1" :status] :preparing)))
+          chat-ctx  {:db*       db*
+                     :config    (h/config)
+                     :chat-id   chat-id
+                     :provider  provider
+                     :agent     :default
+                     :messenger (h/messenger)
+                     :metrics   (h/metrics)}
+          received-msgs* (atom "")
+          add-to-history! (fn [msg]
+                            (swap! db* update-in [:chats chat-id :messages] (fnil conj []) msg))
+          tool-calls [{:id           "call-1"
+                       :full-name    "eca__test_tool"
+                       :arguments    {}
+                       :arguments-text "{}"}]
+          all-tools  [{:name      "test_tool"
+                       :full-name "eca__test_tool"
+                       :origin    :eca
+                       :server    {:name "eca"}}]]
+      (with-redefs [f.tools/all-tools                           (constantly all-tools)
+                    f.tools/approval                            (constantly :deny)
+                    f.hooks/trigger-if-matches!                 (fn [_ _ _ _ _] nil)
+                    f.tools/call-tool!                          (fn [& _] {:contents [{:text "ignored" :type :text}]})
+                    f.tools/tool-call-details-before-invocation (constantly nil)
+                    f.tools/tool-call-details-after-invocation  (constantly nil)
+                    f.tools/tool-call-summary                   (constantly "Test tool")
+                    lifecycle/maybe-renew-auth-token
+                    (fn [ctx]
+                      (swap! (:db* ctx) update-in [:auth provider] merge renewed-provider-auth))]
+        (let [result ((tc/on-tools-called! chat-ctx received-msgs* add-to-history! []) tool-calls)]
+          (is (some? result)
+              "subagent rejection path must continue the loop (non-nil) instead of aborting")
+          (is (= (:api-key renewed-provider-auth) (:fresh-api-key result))
+              "rejection path must also return fresh api-key so the next subagent request uses the renewed token")
+          (is (= (:api-key renewed-provider-auth) (:api-key (:provider-auth result)))
+              "rejection path must also return refreshed provider-auth"))))))

--- a/test/eca/llm_api_test.clj
+++ b/test/eca/llm_api_test.clj
@@ -210,6 +210,53 @@
             :provider-auth {:api-key "test-key"}}
            (dissoc overrides :stream))))
 
+(deftest refresh-provider-auth-fn-used-for-initial-and-retry-test
+  (testing "refresh-provider-auth-fn supplies a fresh provider-auth on each prompt! call"
+    ;; Previously provider-auth was captured once and reused across retries,
+    ;; so expired tokens caused all retries to fail.
+    (let [refresh-calls* (atom 0)
+          seen-api-keys* (atom [])]
+      (with-redefs [eca.llm-api/prompt! (fn [{:keys [provider-auth]}]
+                                          (swap! seen-api-keys* conj (:api-key provider-auth))
+                                          (let [attempt (count @seen-api-keys*)]
+                                            (if (= 1 attempt)
+                                              {:error {:status 429
+                                                       :body "Rate limit exceeded"
+                                                       :message "LLM response status: 429"}}
+                                              {:output-text "success"
+                                               :usage {:input-tokens 1 :output-tokens 1}})))
+                    eca.llm-api/sleep-with-cancel (fn [_ cancelled?] (not (cancelled?)))]
+        (llm-api/sync-or-async-prompt!
+         (make-prompt-opts
+          {:stream false
+           :provider-auth {:api-key "stale-token"}
+           :refresh-provider-auth-fn (fn []
+                                       (let [n (swap! refresh-calls* inc)]
+                                         {:api-key (str "fresh-token-" n)}))
+           :on-error identity
+           :on-message-received identity})))
+      (is (= 2 @refresh-calls*)
+          "refresh-provider-auth-fn is called once per prompt! attempt (initial + retry)")
+      (is (= ["fresh-token-1" "fresh-token-2"] @seen-api-keys*)
+          "each prompt! invocation (including the retry) must see a freshly read api-key")))
+
+  (testing "falls back to captured provider-auth when refresh-provider-auth-fn throws"
+    (let [seen-api-keys* (atom [])]
+      (with-redefs [eca.llm-api/prompt! (fn [{:keys [provider-auth]}]
+                                          (swap! seen-api-keys* conj (:api-key provider-auth))
+                                          {:output-text "ok"
+                                           :usage {:input-tokens 1 :output-tokens 1}})
+                    eca.llm-api/sleep-with-cancel (fn [_ _] true)]
+        (llm-api/sync-or-async-prompt!
+         (make-prompt-opts
+          {:stream false
+           :provider-auth {:api-key "fallback-token"}
+           :refresh-provider-auth-fn (fn [] (throw (ex-info "boom" {})))
+           :on-error identity
+           :on-message-received identity})))
+      (is (= ["fallback-token"] @seen-api-keys*)
+          "when refresh-provider-auth-fn throws, prompt! keeps running with the statically captured provider-auth"))))
+
 (deftest sync-retry-on-rate-limited-test
   (testing "retries on 429 and succeeds on subsequent attempt"
     (let [attempt* (atom 0)


### PR DESCRIPTION
Provider auth was captured once at prompt start and reused across retries and within-stream tool rounds. If a token expired during a long-running tool call (e.g. spawn_agent), all subsequent requests used the stale key.

Two-layer fix:
- Layer 1 (llm_api): refresh-provider-auth-fn called before each prompt! invocation, covering initial calls and retries
- Layer 2 (tool_calls): with-fresh-auth helper ensures all continuation branches (including rejections) propagate refreshed credentials back to the provider's streaming loop

Also restores missing messages-after-last-compact-marker in the no-continue-fn fallback path.


- [ ] I added a entry in changelog under unreleased section.
- [ ] This is not an AI slop.
