### PR TITLE
Fix agent switching cache issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix agent switching (e.g. "code" → "plan") not taking effect mid-conversation for OpenAI Responses API models (openai/gpt-5.3-codex, github-copilot/gpt-5.3-codex). The static system prompt cache is now keyed per agent and invalidated on agent change.
+
 ## 0.126.0
 
 - Chat titles now re-generate at the 3rd user message using full conversation context for more accurate titles.

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -612,6 +612,7 @@
                 :model-capabilities model-capabilities
                 :user-messages user-messages
                 :instructions  instructions
+                :agent agent
                 :past-messages (shared/messages-after-last-compact-marker
                                 (get-in @db* [:chats chat-id :messages] []))
                 :config  config
@@ -1009,14 +1010,17 @@
                           (f.context/agents-file-contexts db)
                           (f.context/raw-contexts->refined contexts db))
         repo-map* (delay (f.index/repo-map db config {:as-string? true}))
-        cached-static (get-in db [:chats chat-id :prompt-cache :static])
+        prompt-cache (get-in db [:chats chat-id :prompt-cache])
+        cached-static (when (= (:agent prompt-cache) agent)
+                        (:static prompt-cache))
         instructions (if cached-static
                        {:static cached-static
                         :dynamic (f.prompt/build-dynamic-instructions refined-contexts db)}
                        (let [result (f.prompt/build-chat-instructions
                                      refined-contexts rules skills repo-map*
                                      agent config chat-id all-tools db)]
-                         (swap! db* assoc-in [:chats chat-id :prompt-cache :static] (:static result))
+                         (swap! db* update-in [:chats chat-id :prompt-cache]
+                                assoc :static (:static result) :agent agent)
                          result))
         image-contents (->> refined-contexts
                             (filter #(= :image (:type %))))

--- a/src/eca/llm_api.clj
+++ b/src/eca/llm_api.clj
@@ -167,7 +167,7 @@
       merged)))
 
 (defn ^:private prompt!
-  [{:keys [provider model model-capabilities instructions user-messages config variant
+  [{:keys [provider model model-capabilities instructions user-messages config variant agent
            on-message-received on-error on-prepare-tool-call on-tools-called on-reason on-usage-updated on-server-web-search
            past-messages tools provider-auth sync? subagent? cancelled?]
     :or {on-error identity}}]
@@ -203,6 +203,7 @@
         (handler
          {:model real-model
           :instructions flat-instructions
+          :agent agent
           :user-messages user-messages
           :max-output-tokens max-output-tokens
           :reason? reason?
@@ -254,6 +255,7 @@
                                        extra-headers))
               base-opts {:model real-model
                          :instructions flat-instructions
+                         :agent agent
                          :user-messages user-messages
                          :max-output-tokens max-output-tokens
                          :reason? reason?
@@ -353,7 +355,7 @@
 (defn sync-or-async-prompt!
   [{:keys [provider model model-capabilities instructions user-messages config on-first-response-received
            on-message-received on-error on-prepare-tool-call on-tools-called on-reason on-usage-updated on-server-web-search
-           past-messages tools provider-auth refresh-provider-auth-fn variant cancelled? on-retry subagent?]
+           past-messages tools provider-auth refresh-provider-auth-fn variant cancelled? on-retry subagent? agent]
     :or {on-first-response-received identity
          on-message-received identity
          on-error identity
@@ -441,6 +443,7 @@
                               :model model
                               :model-capabilities model-capabilities
                               :instructions instructions
+                              :agent agent
                               :tools tools
                               :provider-auth (fresh-provider-auth)
                               :past-messages past-messages
@@ -476,6 +479,7 @@
                 :model model
                 :model-capabilities model-capabilities
                 :instructions instructions
+                :agent agent
                 :tools tools
                 :provider-auth (fresh-provider-auth)
                 :past-messages past-messages

--- a/src/eca/llm_api.clj
+++ b/src/eca/llm_api.clj
@@ -328,6 +328,7 @@
           (handler
            {:model real-model
             :instructions flat-instructions
+            :agent agent
             :user-messages user-messages
             :max-output-tokens max-output-tokens
             :web-search web-search

--- a/src/eca/llm_providers/openai.clj
+++ b/src/eca/llm_providers/openai.clj
@@ -152,7 +152,7 @@
          tools)
     (and web-search (not codex?)) (conj {:type "web_search_preview"})))
 
-(defn create-response! [{:keys [model user-messages instructions reason? supports-image? api-key api-url url-relative-path
+(defn create-response! [{:keys [model user-messages instructions agent reason? supports-image? api-key api-url url-relative-path
                                 max-output-tokens past-messages tools web-search extra-payload extra-headers auth-type account-id http-client]}
                         {:keys [on-message-received on-error on-prepare-tool-call on-tools-called on-reason on-usage-updated on-server-web-search] :as callbacks}]
   (let [codex? (= :auth/oauth auth-type)
@@ -165,7 +165,7 @@
                 :input (if codex?
                          (concat [{:role "system" :content instructions}] input)
                          input)
-                :prompt_cache_key (str (System/getProperty "user.name") "@ECA")
+                :prompt_cache_key (str (System/getProperty "user.name") "@ECA" (when agent (str "/" agent)))
                 :instructions instructions
                 :tools tools
                 :include (when reason?

--- a/test/eca/features/chat_test.clj
+++ b/test/eca/features/chat_test.clj
@@ -931,6 +931,7 @@
 (deftest prompt-cache-agent-switch-test
   (testing "agent switching invalidates static prompt cache"
     (h/reset-components!)
+    (h/config! {:agent {"code" {:mode "primary"} "plan" {:mode "primary"}}})
     (let [build-calls* (atom 0)
           api-mock (fn [{:keys [on-first-response-received on-message-received]}]
                      (on-first-response-received {:type :text :text "ok"})

--- a/test/eca/features/chat_test.clj
+++ b/test/eca/features/chat_test.clj
@@ -927,3 +927,30 @@
              (h/messages)))))))
 
 
+
+(deftest prompt-cache-agent-switch-test
+  (testing "agent switching invalidates static prompt cache"
+    (h/reset-components!)
+    (let [build-calls* (atom 0)
+          api-mock (fn [{:keys [on-first-response-received on-message-received]}]
+                     (on-first-response-received {:type :text :text "ok"})
+                     (on-message-received {:type :text :text "ok"})
+                     (on-message-received {:type :finish}))
+          base-mocks {:all-tools-mock (constantly [])
+                      :api-mock api-mock
+                      :call-tool-mock (constantly nil)}]
+      (with-redefs [f.prompt/build-chat-instructions
+                    (fn [& _]
+                      (swap! build-calls* inc)
+                      {:static (str "static-" @build-calls*)
+                       :dynamic "dynamic"})]
+        (let [{:keys [chat-id]} (prompt! {:message "Hello" :agent "code"} base-mocks)]
+          (is (= 1 @build-calls*) "First call should build instructions")
+
+          (h/reset-messenger!)
+          (prompt! {:message "Hello again" :chat-id chat-id :agent "code"} base-mocks)
+          (is (= 1 @build-calls*) "Same agent reuses cached static instructions")
+
+          (h/reset-messenger!)
+          (prompt! {:message "Switch" :chat-id chat-id :agent "plan"} base-mocks)
+          (is (= 2 @build-calls*) "Different agent should rebuild instructions"))))))

--- a/test/eca/llm_providers/openai_test.clj
+++ b/test/eca/llm_providers/openai_test.clj
@@ -1,5 +1,6 @@
 (ns eca.llm-providers.openai-test
   (:require
+   [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]
    [eca.client-test-helpers :refer [with-client-proxied]]
    [eca.llm-providers.openai :as llm-providers.openai]
@@ -437,3 +438,30 @@
                       :arguments {"command" "ls"}}]
                     (first @tools-called*)))
         (is (= 2 (count @requests*)))))))
+
+(deftest create-response-prompt-cache-key-agent-test
+  (testing "prompt_cache_key includes agent suffix when agent is provided"
+    (let [body* (atom nil)]
+      (with-redefs [llm-providers.openai/base-responses-request!
+                    (fn [{:keys [body on-stream]}]
+                      (reset! body* body)
+                      (on-stream "response.completed"
+                                 {:response {:output [] :usage {:input_tokens 1 :output_tokens 1}}}))]
+        (llm-providers.openai/create-response!
+         (assoc (base-provider-params) :agent "plan")
+         (base-callbacks {}))
+        (is (string/ends-with? (:prompt_cache_key @body*) "/plan")
+            "prompt_cache_key should end with /plan"))))
+
+  (testing "prompt_cache_key has no agent suffix when agent is nil"
+    (let [body* (atom nil)]
+      (with-redefs [llm-providers.openai/base-responses-request!
+                    (fn [{:keys [body on-stream]}]
+                      (reset! body* body)
+                      (on-stream "response.completed"
+                                 {:response {:output [] :usage {:input_tokens 1 :output_tokens 1}}}))]
+        (llm-providers.openai/create-response!
+         (base-provider-params)
+         (base-callbacks {}))
+        (is (not (string/includes? (:prompt_cache_key @body*) "/"))
+            "prompt_cache_key should not contain / when agent is nil")))))


### PR DESCRIPTION
Changing the agent when using OpenAI models via the Responses API did not have an affect on the system prompt, so I couldn't switch between planning mode and code mode. This PR fixes the problem by invalidating the prompt cache when the agent is changed. Testing locally the model now sees the agent has changed:

```
> Are you in planner mode?

Thought 0s

Not currently—I’m in normal execution mode.

If you want, I can switch to a **planner-style workflow** (create a task list, track steps, and execute in order) for the next task.

**[Agent switched to planner mode]**

> HOw about now?

Thought 2s

Yes — now I’m in **planner mode** for this chat.

I’ll focus on planning only (Understand → Explore → Decide → Present Plan), and I won’t modify files unless you explicitly ask for a preview.

```


 

# Copilot summary

This pull request fixes a bug where switching agents (such as from "code" to "plan") during a conversation with OpenAI Responses API models did not take effect immediately, due to static system prompt caching not being properly keyed per agent. The cache is now correctly invalidated and rebuilt when the agent changes. Additionally, tests have been added to ensure the cache behaves as expected, and the agent is now included in the prompt cache key for OpenAI requests.

**Bug Fix: Agent Switching and Prompt Cache**

* Static prompt cache in chat is now keyed by `agent` and invalidated when the agent changes, ensuring agent switches (e.g., "code" → "plan") take effect immediately for OpenAI Responses API models (`openai/gpt-5.3-codex`, `github-copilot/gpt-5.3-codex`). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R6) [[2]](diffhunk://#diff-778659254ceb73b7a429cfdeca687115ff7afca424d37d4d6be232ff406f1006L1012-R1023)

**Code Changes: Agent Propagation**

* The `agent` parameter is now passed through all relevant chat and LLM API functions, including `prompt!`, `sync-or-async-prompt!`, and provider-specific calls, ensuring correct context and cache behavior. [[1]](diffhunk://#diff-778659254ceb73b7a429cfdeca687115ff7afca424d37d4d6be232ff406f1006R615) [[2]](diffhunk://#diff-05bf08a752baa510c8ee8dbaa6ce6a082e4334657db36013f0ef342985794d20L170-R170) [[3]](diffhunk://#diff-05bf08a752baa510c8ee8dbaa6ce6a082e4334657db36013f0ef342985794d20L356-R359) [[4]](diffhunk://#diff-05bf08a752baa510c8ee8dbaa6ce6a082e4334657db36013f0ef342985794d20R206) [[5]](diffhunk://#diff-05bf08a752baa510c8ee8dbaa6ce6a082e4334657db36013f0ef342985794d20R258) [[6]](diffhunk://#diff-05bf08a752baa510c8ee8dbaa6ce6a082e4334657db36013f0ef342985794d20R331) [[7]](diffhunk://#diff-05bf08a752baa510c8ee8dbaa6ce6a082e4334657db36013f0ef342985794d20R447) [[8]](diffhunk://#diff-05bf08a752baa510c8ee8dbaa6ce6a082e4334657db36013f0ef342985794d20R483) [[9]](diffhunk://#diff-61a735881587da3e2c2e255d6bead7e5f8af9cd248fc23d29dbca33e133291acL155-R155)

**OpenAI Provider: Prompt Cache Key**

* The `prompt_cache_key` for OpenAI requests now includes the agent name as a suffix when present, ensuring cache separation per agent.

**Testing Improvements**

* Added a test (`prompt-cache-agent-switch-test`) to verify that switching agents invalidates and rebuilds the static prompt cache.
* Added a test to ensure `prompt_cache_key` includes the agent suffix when provided and omits it when not. [[1]](diffhunk://#diff-cd3a7a610c2c5922a3e7d6130e59b4ec33e67c891406da7acec4c4fb8c2fc228R3) [[2]](diffhunk://#diff-cd3a7a610c2c5922a3e7d6130e59b4ec33e67c891406da7acec4c4fb8c2fc228R441-R467)

These changes ensure that agent switching works as intended and that caching is correctly scoped, preventing stale prompts from being used when the agent changes.

- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
