### PR TITLE
Add support for gpt-5.5 variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add support for gpt-5.5 variants
+
 ## 0.129.1
 
 - Fix token usage not being reported in the UI for Google/Gemini (and other strict OpenAI-compat providers) by opting into `stream_options.include_usage` on streaming chat completion requests. #414

--- a/src/eca/config.clj
+++ b/src/eca/config.clj
@@ -183,7 +183,7 @@
               :outputTruncation {:lines 2000 :sizeKb 50}}
    :variantsByModel {".*sonnet[-._]4[-._]6|opus[-._]4[-._][56]" {:variants anthropic-variants}
                      ".*opus[-._]4[-._]7" {:variants anthropic-v2-variants}
-                     ".*gpt[-._]5(?:[-._](?:2|4)(?!\\d)|[-._]3[-._]codex)" {:variants openai-variants
+                     ".*gpt[-._]5(?:[-._](?:2|4|5)(?!\\d)|[-._]3[-._]codex)" {:variants openai-variants
                                                                             :excludeProviders ["github-copilot"]}}
    :mcpTimeoutSeconds 60
    :lspTimeoutSeconds 30


### PR DESCRIPTION
Extend the variantsByModel regex to match gpt-5.5 models, giving them the same OpenAI reasoning-effort variants as gpt-5.2 and gpt-5.4.

🤖 Generated with [eca](https://eca.dev)


- x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
