### PR TITLE
Support selector-based hook matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - MCP tools that return image content blocks (e.g. an MCP image-generation/edit server) now render those images in the chat UI as `ChatImageContent` and replay them back to the LLM as image inputs on follow-up turns when the model supports vision. Implemented for `openai-responses` (synthetic user-role `input_image` after the `function_call_output`) and `anthropic` (mixed text + image blocks inside `tool_result.content`). `openai-chat` and `ollama` continue to receive a text placeholder until a parallel pattern is implemented there.
 - Bugfix: MCP tools without a `description` (which the MCP spec marks optional) no longer break Anthropic chat requests with `tools.<n>.custom.description: Input should be a valid string`. Missing/empty descriptions now fall back to the tool's `title`, then to a synthesized `MCP tool: <name>` string at the MCP boundary so all providers receive a non-null string.
+- Hook `matcher` now supports object form keyed by tool selectors with per-tool `argsMatchers`; legacy string regex matchers remain supported.
 
 ## 0.131.0
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -755,9 +755,23 @@
           ]
         },
         "matcher": {
-          "type": "string",
-          "description": "Regex pattern for matching server__tool-name. Only for *ToolCall hook types.",
-          "markdownDescription": "Regex pattern for matching server__tool-name. Only for *ToolCall hook types."
+          "description": "Matches *ToolCall hooks; unmatched hooks are skipped. String: legacy regex against server__tool-name. Object: tool selector map with optional argsMatchers.",
+          "markdownDescription": "Matches `*ToolCall` hooks; unmatched hooks are skipped. **String**: legacy regex against `server__tool-name`. **Object**: tool selector map with optional `argsMatchers`.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Regex pattern for matching server__tool-name.",
+              "markdownDescription": "Regex pattern for matching `server__tool-name`."
+            },
+            {
+              "type": "object",
+              "description": "Tool selector map. Keys follow toolApproval selectors: full tool name (server__tool-name), native ECA tool name, or server name. Empty rule {} matches without argument filtering.",
+              "markdownDescription": "Tool selector map. Keys follow `toolApproval` selectors: full tool name (`server__tool-name`), native ECA tool name, or server name. Empty rule `{}` matches without argument filtering.",
+              "additionalProperties": {
+                "$ref": "#/definitions/hookMatcherEntry"
+              }
+            }
+          ]
         },
         "visible": {
           "type": "boolean",
@@ -1000,6 +1014,25 @@
           "type": "object",
           "description": "Map of argument name to list of Java regex patterns to match against.",
           "markdownDescription": "Map of argument name to list of Java regex patterns to match against.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "hookMatcherEntry": {
+      "type": "object",
+      "description": "Hook matcher rule. Use argsMatchers to require argument values to match Java regex patterns.",
+      "markdownDescription": "Hook matcher rule. Use `argsMatchers` to require argument values to match Java regex patterns.",
+      "properties": {
+        "argsMatchers": {
+          "type": "object",
+          "description": "Tool argument name to Java regex alternatives. Every listed argument must exist and match at least one pattern.",
+          "markdownDescription": "Tool argument name to Java regex alternatives. Every listed argument must exist and match at least one pattern.",
           "additionalProperties": {
             "type": "array",
             "items": {

--- a/docs/config/hooks.md
+++ b/docs/config/hooks.md
@@ -24,7 +24,7 @@ Hooks are shell actions that run before or after specific events, useful for not
 
 ## Hook Options
 
-- **`matcher`**: Regex for `server__tool-name`, only for `*ToolCall` hooks.
+- **`matcher`**: For `*ToolCall` hooks. String = legacy regex for `server__tool-name`. Object = tool selector map with optional `argsMatchers`. Selectors follow tool approval: full tool name (`eca__write_file`), native ECA tool name (`write_file`), or server name. In `argsMatchers`, keys are tool argument names and values are arrays of regex alternatives for that argument. All listed arguments must match; multiple regexes for one argument are alternatives.
 - **`visible`**: Show hook execution in chat (default: `true`).
 - **`runOnError`**: For `postToolCall`, run even if tool errored (default: `false`).
 
@@ -169,6 +169,26 @@ To reject a tool call, either output `{"approval": "deny"}` or exit with code `2
             "type": "shell",
             "shell": "echo '{\"updatedInput\": {\"max_depth\": 3}}'"
           }]
+        }
+      }
+    }
+    ```
+
+=== "Match tool arguments"
+
+    ```javascript title="~/.config/eca/config.json"
+    {
+      "hooks": {
+        "check-allium": {
+          "type": "postToolCall",
+          "matcher": {
+            "eca__write_file": {
+              "argsMatchers": {
+                "path": [".*\\.allium$"]
+              }
+            }
+          },
+          "actions": [{"type": "shell", "file": "hooks/check-allium.sh"}]
         }
       }
     }

--- a/src/eca/config.clj
+++ b/src/eca/config.clj
@@ -452,6 +452,8 @@
     [:providers :ANY :models]
     [:providers :ANY :models :ANY :extraHeaders]
     [:providers :ANY :models :ANY :variants]
+    [:hooks :ANY :matcher]
+    [:hooks :ANY :matcher :ANY :argsMatchers]
     [:toolCall :approval :allow]
     [:toolCall :approval :allow :ANY :argsMatchers]
     [:toolCall :approval :ask]

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -282,9 +282,9 @@
 (defn ^:private update-pre-request-state
   "Pure function to compute new state from hook result."
   [{:keys [final-prompt additional-contexts stop?]} {:keys [parsed raw-output exit]} action-name]
-  (let [replaced-prompt (:replacedPrompt parsed)
+  (let [replaced-prompt (get parsed "replacedPrompt")
         additional-context (if parsed
-                             (:additionalContext parsed)
+                             (get parsed "additionalContext")
                              raw-output)
         success? (= 0 exit)]
     {:final-prompt (if (and replaced-prompt success?)
@@ -295,7 +295,7 @@
                                   {:hook-name action-name :content additional-context})
                             additional-contexts)
      :stop? (or stop?
-                (false? (get parsed :continue true)))}))
+                (false? (get parsed "continue" true)))}))
 
 (defn ^:private run-pre-request-action!
   "Run a single preRequest hook action, updating the accumulator state.
@@ -326,7 +326,7 @@
                                                         :all-messages (:all-messages state)})
                                                 db)]
         (let [{:keys [parsed raw-output raw-error exit]} result
-              should-continue? (get parsed :continue true)]
+              should-continue? (get parsed "continue" true)]
           ;; Notify after action
           (lifecycle/notify-after-hook-action! chat-ctx (merge result
                                                                {:id id
@@ -338,7 +338,7 @@
                                                                 :error raw-error}))
           ;; Check if hook wants to stop
           (when (false? should-continue?)
-            (when-let [stop-reason (:stopReason parsed)]
+            (when-let [stop-reason (get parsed "stopReason")]
               (lifecycle/send-content! chat-ctx :system {:type :text :text stop-reason}))
             (lifecycle/finish-chat-prompt! :idle chat-ctx))
           ;; Update accumulator
@@ -1148,7 +1148,7 @@
                                            config)
               ;; Collect additionalContext from all chatStart hooks and store
               ;; it as startup-context for this chat.
-              (when-let [additional-contexts (seq (keep #(get-in % [:parsed :additionalContext]) @hook-results*))]
+              (when-let [additional-contexts (seq (keep #(get-in % [:parsed "additionalContext"]) @hook-results*))]
                 (swap! db* assoc-in [:chats chat-id :startup-context]
                        (string/join "\n\n" additional-contexts)))
               ;; Mark chatStart as fired for this chat in this server run

--- a/src/eca/features/chat/lifecycle.clj
+++ b/src/eca/features/chat/lifecycle.clj
@@ -38,7 +38,7 @@
 
 (defn- format-hook-output
   "Format hook output for display, showing parsed JSON fields or raw output."
-  [{:keys [systemMessage replacedPrompt additionalContext] :as parsed} raw-output]
+  [{:strs [systemMessage replacedPrompt additionalContext] :as parsed} raw-output]
   (if parsed
     (cond-> (or systemMessage "Hook executed")
       replacedPrompt  (str "\nReplacedPrompt: " (pr-str replacedPrompt))
@@ -54,7 +54,7 @@
                     :id id})))
 
 (defn notify-after-hook-action! [chat-ctx {:keys [id name parsed raw-output raw-error exit type visible?]}]
-  (when (and visible? (not (:suppressOutput parsed)))
+  (when (and visible? (not (get parsed "suppressOutput")))
     (send-content! chat-ctx :system
                    {:type :hookActionFinished
                     :action-type type

--- a/src/eca/features/chat/tool_calls.clj
+++ b/src/eca/features/chat/tool_calls.clj
@@ -65,7 +65,9 @@
   "Run postToolCall hooks and append any additionalContext to the tool output."
   [db* chat-ctx tool-call-id event-data]
   (let [tool-call-state (get-tool-call-state @db* (:chat-id chat-ctx) tool-call-id)
-        chat-id (:chat-id chat-ctx)]
+        chat-id (:chat-id chat-ctx)
+        native-tools (filter #(= :native (:origin %))
+                             (f.tools/all-tools chat-id (:agent chat-ctx) @db* (:config chat-ctx)))]
     (f.hooks/trigger-if-matches!
      :postToolCall
      (merge (f.hooks/chat-hook-data @db* chat-id (:agent chat-ctx))
@@ -79,13 +81,14 @@
                          ;; Always notify UI
                          (lifecycle/notify-after-hook-action! chat-ctx result)
                          ;; If hook provided additionalContext, append as XML to the tool output
-                         (when-let [ac (:additionalContext parsed)]
+                         (when-let [ac (get parsed "additionalContext")]
                            (append-post-tool-additional-context!
                             (:db* chat-ctx)
                             (:chat-id chat-ctx)
                             tool-call-id
                             name
-                            ac)))}
+                            ac)))
+      :native-tools native-tools}
      @db*
      (:config chat-ctx))))
 
@@ -524,17 +527,17 @@
            :hook-rejection-reason nil, :hook-continue true, :hook-stop-reason nil}"
   [acc result]
   (let [parsed (:parsed result)
-        hook-approval (:approval parsed)
+        hook-approval (get parsed "approval")
         exit-code-2? (= f.hooks/hook-rejection-exit-code (:exit result))]
     (cond-> (update acc :hook-results conj result)
       ;; Handle rejection (exit code 2 or explicit deny)
       (or exit-code-2? (= "deny" hook-approval))
       (merge {:hook-rejected? true
-              :hook-rejection-reason (or (:additionalContext parsed)
+              :hook-rejection-reason (or (get parsed "additionalContext")
                                          (:raw-error result)
                                          "Tool call rejected by hook")
-              :hook-continue (get parsed :continue true)
-              :hook-stop-reason (:stopReason parsed)})
+              :hook-continue (get parsed "continue" true)
+              :hook-stop-reason (get parsed "stopReason")})
 
       ;; Handle approval override (allow/ask) when not exit-code-2
       (and hook-approval (not exit-code-2?))
@@ -562,6 +565,7 @@
         name (:name tool)
         server (:server tool)
         server-name (:name server)
+        native-tools (filter #(= :native (:origin %)) all-tools)
 
         ;; 1. Determine approval (trust promotion handled inside f.tools/approval)
         approval (f.tools/approval all-tools tool arguments db config agent-name {:trust trust})
@@ -596,14 +600,15 @@
            {:on-before-action on-before-hook-action
             :on-after-action (fn [result]
                                (on-after-hook-action result)
-                               (swap! hook-state* process-pre-tool-call-hook-result result))}
+                               (swap! hook-state* process-pre-tool-call-hook-result result))
+            :native-tools native-tools}
            db
            config)
 
         ;; 3. Merge all updatedInput from hooks
         {:keys [hook-results approval-override hook-rejected?
                 hook-rejection-reason hook-continue hook-stop-reason]} @hook-state*
-        updated-inputs (keep #(get-in % [:parsed :updatedInput]) hook-results)
+        updated-inputs (keep #(get-in % [:parsed "updatedInput"]) hook-results)
         final-arguments (if (not-empty updated-inputs)
                           (reduce merge arguments updated-inputs)
                           arguments)

--- a/src/eca/features/hooks.clj
+++ b/src/eca/features/hooks.clj
@@ -3,9 +3,10 @@
    [babashka.fs :as fs]
    [babashka.process :as p]
    [cheshire.core :as json]
+   [eca.features.tools.shell :as f.tools.shell]
+   [eca.features.tools.util :as tools.util]
    [eca.logger :as logger]
-   [eca.shared :as shared]
-   [eca.features.tools.shell :as f.tools.shell]))
+   [eca.shared :as shared]))
 
 (def ^:private logger-tag "[HOOK]")
 
@@ -35,7 +36,7 @@
   [output]
   (when (and output (not-empty output))
     (try
-      (let [parsed (json/parse-string output true)]
+      (let [parsed (json/parse-string output)]
         (if (map? parsed)
           parsed
           (logger/debug logger-tag "Hook JSON output must result in map")))
@@ -70,22 +71,84 @@
        (not (get hook :runOnError false))
        (:error data)))
 
-(defn ^:private hook-matches? [hook-type data hook]
+(defn ^:private parse-matcher-rules
+  "Returns normalized rules for missing, string, or object hook matchers.
+   String matchers stay legacy regex rules; object matcher keys become tool selector rules."
+  [matcher]
+  (cond
+    (nil? matcher)
+    [{:kind :regex :pattern ".*"}]
+
+    (string? matcher)
+    [{:kind :regex :pattern matcher}]
+
+    (map? matcher)
+    (->> matcher
+         (keep (fn [[tool-selector config]]
+                 (if (map? config)
+                   {:kind :selector
+                    :selector (tools.util/selector->string tool-selector)
+                    :args-matchers (:argsMatchers config)}
+                   (logger/warn logger-tag "Ignoring non-map matcher entry for selector" {:selector tool-selector}))))
+         vec)
+
+    :else
+    []))
+
+(defn ^:private arg-value [tool-input arg-name]
+  (when (map? tool-input)
+    (when-let [arg-str (tools.util/selector->string arg-name)]
+      (get tool-input arg-str))))
+
+(defn ^:private regex-matches? [pattern value]
+  (try
+    (boolean (re-matches (re-pattern (str pattern)) (str value)))
+    (catch Exception e
+      (logger/warn logger-tag "Invalid hook matcher regex" {:pattern (str pattern)
+                                                            :error (.getMessage e)})
+      false)))
+
+(defn ^:private args-match?
+  "Matches all configured argument rules.
+   Patterns within a single argument are ORed; arguments are ANDed; missing arguments do not match."
+  [args-matchers tool-input]
+  (cond
+    (or (nil? args-matchers)
+        (and (map? args-matchers) (empty? args-matchers)))
+    true
+
+    (not (map? args-matchers))
+    false
+
+    :else
+    (every? (fn [[arg-name matchers]]
+              (let [value (arg-value tool-input arg-name)]
+                (and (some? value)
+                     (sequential? matchers)
+                     (some #(regex-matches? % value) matchers))))
+            args-matchers)))
+
+(defn ^:private hook-matches? [hook-type data hook native-tools]
   (let [hook-config-type (keyword (:type hook))
         hook-config-type (cond ;; legacy values
                            (= :prePrompt hook-config-type) :preRequest
                            (= :postPrompt hook-config-type) :postRequest
                            :else hook-config-type)]
     (cond
-      (not= hook-type hook-config-type)
-      false
-
-      (should-skip-on-error? hook-type hook data)
+      (or (not= hook-type hook-config-type)
+          (should-skip-on-error? hook-type hook data))
       false
 
       (contains? #{:preToolCall :postToolCall} hook-type)
-      (re-matches (re-pattern (or (:matcher hook) ".*"))
-                  (str (:server data) "__" (:tool-name data)))
+      (let [rules (parse-matcher-rules (:matcher hook))
+            full-name (str (:server data) "__" (:tool-name data))]
+        (some (fn [{:keys [kind pattern selector args-matchers]}]
+                (case kind
+                  :regex (regex-matches? pattern full-name)
+                  :selector (and (tools.util/tool-selector-matches? selector (:server data) (:tool-name data) native-tools)
+                                 (args-match? args-matchers (:tool-input data)))
+                  false))
+              rules))
 
       :else
       true)))
@@ -145,14 +208,14 @@
   "Run hook of specified type if matches any config for that type"
   [hook-type
    data
-   {:keys [on-before-action on-after-action]
+   {:keys [on-before-action on-after-action native-tools]
     :or {on-before-action identity
          on-after-action identity}}
    db
    config]
   ;; Sort hooks by name to ensure deterministic execution order.
   (doseq [[name hook] (sort-by key (:hooks config))]
-    (when (hook-matches? hook-type data hook)
+    (when (hook-matches? hook-type data hook native-tools)
       (vec
        (map-indexed (fn [i action]
                       (let [id (str (random-uuid))

--- a/src/eca/features/tools.clj
+++ b/src/eca/features/tools.clj
@@ -37,23 +37,9 @@
       manual-approval?)))
 
 (defn ^:private approval-matches? [[server-or-full-tool-name config] tool-call-server tool-call-name args native-tools]
-  (let [args-matchers (:argsMatchers config)
-        [server-name tool-name] (if (string/includes? server-or-full-tool-name "__")
-                                  (string/split server-or-full-tool-name #"__" 2)
-                                  (if (some #(= server-or-full-tool-name (:name %)) native-tools)
-                                    ["eca" server-or-full-tool-name]
-                                    [server-or-full-tool-name nil]))]
+  (let [args-matchers (:argsMatchers config)]
     (cond
-      ;; specified server name in config
-      (and (nil? tool-name)
-           ;; but the name doesn't match
-           (not= tool-call-server server-name))
-      false
-
-      ;; tool or server not match
-      (and tool-name
-           (or (not= tool-call-server server-name)
-               (not= tool-call-name tool-name)))
+      (not (tools.util/tool-selector-matches? server-or-full-tool-name tool-call-server tool-call-name native-tools))
       false
 
       (map? args-matchers)

--- a/src/eca/features/tools/util.clj
+++ b/src/eca/features/tools/util.clj
@@ -60,6 +60,27 @@
   [all-tools full-name]
   (boolean (some #(= full-name (:full-name %)) all-tools)))
 
+(defn selector->string [selector]
+  (cond
+    (keyword? selector) (name selector)
+    (string? selector) selector))
+
+(defn tool-selector-matches?
+  "Matches tool selectors used by tool approval and hook object matchers.
+   Selector forms: server__tool exact full name, native ECA tool short name
+   when present in native-tools, otherwise server name."
+  [selector tool-call-server tool-call-name native-tools]
+  (when-let [selector (selector->string selector)]
+    (let [[server-name tool-name] (if (string/includes? selector "__")
+                                    (string/split selector #"__" 2)
+                                    (if (some #(= selector (:name %)) native-tools)
+                                      ["eca" selector]
+                                      [selector nil]))]
+      (if tool-name
+        (and (= tool-call-server server-name)
+             (= tool-call-name tool-name))
+        (= tool-call-server server-name)))))
+
 (defn workspace-roots-strs [db]
   (->> (:workspace-folders db)
        (map #(shared/uri->filename (:uri %)))

--- a/test/eca/features/chat/tool_calls_test.clj
+++ b/test/eca/features/chat/tool_calls_test.clj
@@ -18,7 +18,7 @@
                      :arguments {:foo "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config)
@@ -43,7 +43,7 @@
                      :arguments {:foo "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config)
@@ -66,7 +66,7 @@
                      :arguments {:foo "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config)
@@ -91,7 +91,7 @@
                      :arguments {:foo "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config! {:hooks {"hook1" {:event   "preToolCall"
@@ -104,7 +104,7 @@
                                                   (when (= event :preToolCall)
                                                     (swap! hook-call-count inc)
                                                     (when-let [on-after (:on-after-action callbacks)]
-                                                      (on-after {:parsed {:approval "ask"}
+                                                      (on-after {:parsed {"approval" "ask"}
                                                                  :exit 0}))))]
         (let [plan (#'tc/decide-tool-call-action tool-call all-tools db config agent-name chat-id)]
           (is (= 1 @hook-call-count))
@@ -122,7 +122,7 @@
                      :arguments {:foo "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config! {:hooks {"hook1" {:event   "preToolCall"
@@ -133,7 +133,7 @@
                     f.hooks/trigger-if-matches! (fn [event _ callbacks _ _]
                                                   (when (= event :preToolCall)
                                                     (when-let [on-after (:on-after-action callbacks)]
-                                                      (on-after {:parsed {:additionalContext "Hook rejected"}
+                                                      (on-after {:parsed {"additionalContext" "Hook rejected"}
                                                                  :exit 2
                                                                  :raw-error "Command failed"}))))]
         (let [plan (#'tc/decide-tool-call-action tool-call all-tools db config agent-name chat-id)]
@@ -155,7 +155,7 @@
                      :arguments {:foo "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config)
@@ -182,7 +182,7 @@
                      :arguments {:foo "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config)
@@ -204,7 +204,7 @@
                      :arguments {:foo "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config! {:hooks {"hook1" {:event   "preToolCall"
@@ -229,7 +229,7 @@
                      :arguments {:foo "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config! {:hooks {"hook1" {:event   "preToolCall"
@@ -240,7 +240,7 @@
                     f.hooks/trigger-if-matches! (fn [event _ callbacks _ _]
                                                   (when (= event :preToolCall)
                                                     (when-let [on-after (:on-after-action callbacks)]
-                                                      (on-after {:parsed {:additionalContext "Hook rejected"}
+                                                      (on-after {:parsed {"additionalContext" "Hook rejected"}
                                                                  :exit 2
                                                                  :raw-error "Command failed"}))))]
         (let [plan (#'tc/decide-tool-call-action tool-call all-tools db config agent-name chat-id
@@ -254,10 +254,10 @@
     (h/reset-components!)
     (let [tool-call {:id "call-1"
                      :full-name "eca__test_tool"
-                     :arguments {:foo "bar"}}
+                     :arguments {"foo" "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config! {:hooks {"hook1" {:event   "preToolCall"
@@ -268,11 +268,11 @@
                     f.hooks/trigger-if-matches! (fn [event _ callbacks _ _]
                                                   (when (= event :preToolCall)
                                                     (when-let [on-after (:on-after-action callbacks)]
-                                                      (on-after {:parsed {:updatedInput {:baz "qux"}}
+                                                      (on-after {:parsed {"updatedInput" {"baz" "qux"}}
                                                                  :exit 0}))))]
         (let [plan (#'tc/decide-tool-call-action tool-call all-tools db config agent-name chat-id)]
           (is (match? {:decision :allow
-                       :arguments {:foo "bar" :baz "qux"}
+                       :arguments {"foo" "bar" "baz" "qux"}
                        :approval-override nil
                        :hook-rejected? false
                        :arguments-modified? true}
@@ -285,7 +285,7 @@
                      :arguments {"question" "Why?"}}
           all-tools [{:name "ask_user"
                       :full-name "eca__ask_user"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config)
@@ -311,7 +311,7 @@
                      :arguments {"question" "Why?"}}
           all-tools [{:name "ask_user"
                       :full-name "eca__ask_user"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config)
@@ -334,7 +334,7 @@
                      :arguments {:foo "bar"}}
           all-tools [{:name "test_tool"
                       :full-name "eca__test_tool"
-                      :origin :eca
+                      :origin :native
                       :server {:name "eca"}}]
           db (h/db)
           config (h/config)

--- a/test/eca/features/hooks_test.clj
+++ b/test/eca/features/hooks_test.clj
@@ -2,6 +2,8 @@
   (:require
    [cheshire.core :as json]
    [clojure.test :refer [deftest is testing]]
+   [eca.config :as config]
+   [eca.features.chat.lifecycle :as lifecycle]
    [eca.features.hooks :as f.hooks]
    [eca.test-helper :as h]
    [matcher-combinators.test :refer [match?]]))
@@ -70,7 +72,7 @@
         (f.hooks/trigger-if-matches! :preRequest {:foo "1"}
                                      {:on-after-action (set-action-payload result*)}
                                      (h/db) (h/config)))
-      (is (= "test" (get-in @result* [:parsed :additionalContext])))))
+      (is (= "test" (get-in @result* [:parsed "additionalContext"])))))
 
   (testing "invalid JSON falls back to plain text"
     (h/reset-components!)
@@ -156,10 +158,53 @@
                                      {:server "eca" :tool-name "read"}
                                      {:on-after-action (set-action-payload result*)}
                                      (h/db) (h/config)))
-      (is (= "deny" (get-in @result* [:parsed :approval])))
-      (is (= "Too large" (get-in @result* [:parsed :additionalContext]))))))
+      (is (= "deny" (get-in @result* [:parsed "approval"])))
+      (is (= "Too large" (get-in @result* [:parsed "additionalContext"]))))))
 
 ;;; Lifecycle hooks tests
+
+(deftest hook-action-notification-test
+  (testing "hook output display reads string-keyed parsed JSON fields"
+    (let [sent* (atom [])]
+      (with-redefs [lifecycle/send-content! (fn [_ role content]
+                                              (swap! sent* conj {:role role :content content}))]
+        (lifecycle/notify-after-hook-action!
+         {}
+         {:id "action-1"
+          :name "my-hook"
+          :type "shell"
+          :visible? true
+          :exit 0
+          :parsed {"systemMessage" "Hook done"
+                   "replacedPrompt" "new prompt"
+                   "additionalContext" "extra context"}
+          :raw-output nil
+          :raw-error nil}))
+      (is (= [{:role :system
+               :content {:type :hookActionFinished
+                         :action-type "shell"
+                         :id "action-1"
+                         :name "my-hook"
+                         :status 0
+                         :output "Hook done\nReplacedPrompt: \"new prompt\"\nAdditionalContext: extra context"
+                         :error nil}}]
+             @sent*))))
+
+  (testing "suppressOutput string key hides hook output"
+    (let [sent* (atom [])]
+      (with-redefs [lifecycle/send-content! (fn [_ role content]
+                                              (swap! sent* conj {:role role :content content}))]
+        (lifecycle/notify-after-hook-action!
+         {}
+         {:id "action-1"
+          :name "my-hook"
+          :type "shell"
+          :visible? true
+          :exit 0
+          :parsed {"suppressOutput" true}
+          :raw-output nil
+          :raw-error nil}))
+      (is (empty? @sent*)))))
 
 (deftest session-hooks-test
   (testing "sessionStart has base fields only"
@@ -302,3 +347,294 @@
                                      {:prompt "task"}
                                      {} (h/db) (h/config)))
       (is (false? @ran?*)))))
+
+;;; Matcher map tests (map form with argsMatchers)
+
+(deftest matcher-map-normalization-test
+  (testing "JSON-shaped matcher config works after normalization"
+    (h/reset-components!)
+    ;; This intentionally targets config normalization: hook matcher selector keys
+    ;; must stay strings, otherwise selectors containing / lose their namespace via `name`.
+    (h/config! (#'config/normalize-fields
+                @#'config/normalization-rules
+                {"hooks" {"spec-check" {"type" "preToolCall"
+                                        "matcher" {"vendor/my-mcp__write_file" {"argsMatchers" {"path" [".*\\.allium$"]}}}
+                                        "actions" [{"type" "shell" "shell" "echo ok"}]}}}))
+    (let [result* (atom nil)]
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "vendor/my-mcp" :tool-name "write_file"
+                                      :tool-input {"path" "/foo/bar/spec.allium"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (match? {:name :spec-check} @result*)))))
+
+(deftest matcher-map-test
+  (testing "map matcher with argsMatchers filters by tool argument"
+    (h/reset-components!)
+    (h/config! {:hooks {"spec-check" {:type "preToolCall"
+                                      ;; Simulates config after normalize-fields: matcher and argsMatchers keys may be keywords.
+                                      :matcher {:eca__write_file {:argsMatchers {:path [".*\\.allium$"]}}}
+                                      :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [result* (atom nil)]
+      ;; Should NOT match — wrong extension, with real provider-style string keys.
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/foo/bar/spec.md"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (nil? @result*))
+
+      ;; Should NOT match — required arg is missing.
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"source" "/foo/bar/spec.allium"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (nil? @result*))
+
+      ;; Should match — .allium extension, with real provider-style string keys.
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/foo/bar/spec.allium"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (match? {:name "spec-check"} @result*))))
+
+  (testing "map matcher uses toolApproval-like selectors, not regex"
+    (h/reset-components!)
+    (h/config! {:hooks {"native-write" {:type "preToolCall"
+                                         :matcher {"write_file" {}}
+                                         :actions [{:type "shell" :shell "echo ok"}]}
+                       "server-hook" {:type "preToolCall"
+                                      :matcher {"my-mcp" {}}
+                                      :actions [{:type "shell" :shell "echo ok"}]}
+                       "regex-looking" {:type "preToolCall"
+                                        :matcher {".*write_file" {}}
+                                        :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [native-tools [{:origin :native :name "write_file"}]
+          result* (atom nil)]
+      ;; Native short selector matches only the ECA native tool.
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file" :tool-input {}}
+                                     {:on-after-action (set-action-payload result*)
+                                      :native-tools native-tools}
+                                     (h/db) (h/config)))
+      (is (match? {:name "native-write"} @result*))
+
+      ;; The same short selector must not match an MCP tool with the same name.
+      (reset! result* nil)
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "my-mcp" :tool-name "write_file" :tool-input {}}
+                                     {:on-after-action (set-action-payload result*)
+                                      :native-tools native-tools}
+                                     (h/db) (h/config)))
+      (is (match? {:name "server-hook"} @result*))
+
+      ;; Map keys are selectors, not regexes.
+      (reset! result* nil)
+      (h/reset-components!)
+      (h/config! {:hooks {"regex-looking" {:type "preToolCall"
+                                           :matcher {".*write_file" {}}
+                                           :actions [{:type "shell" :shell "echo ok"}]}}})
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file" :tool-input {}}
+                                     {:on-after-action (set-action-payload result*)
+                                      :native-tools native-tools}
+                                     (h/db) (h/config)))
+      (is (nil? @result*))))
+
+  (testing "postToolCall map matcher supports native short selector"
+    (h/reset-components!)
+    (h/config! {:hooks {"native-write" {:type "postToolCall"
+                                        :matcher {"write_file" {}}
+                                        :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [result* (atom nil)]
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :postToolCall
+                                     {:server "eca" :tool-name "write_file" :tool-input {}}
+                                     {:on-after-action (set-action-payload result*)
+                                      :native-tools [{:origin :native :name "write_file"}]}
+                                     (h/db) (h/config)))
+      (is (match? {:name "native-write"} @result*))))
+
+  (testing "invalid regex matchers are skipped"
+    (h/reset-components!)
+    (h/config! {:hooks {"bad-legacy" {:type "preToolCall"
+                                      :matcher "["
+                                      :actions [{:type "shell" :shell "echo ok"}]}
+                       "bad-args" {:type "preToolCall"
+                                   :matcher {"eca__write_file" {:argsMatchers {"path" ["["]}}}
+                                   :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [result* (atom nil)]
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/foo/spec.allium"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (nil? @result*))))
+
+  (testing "map matcher with empty map value matches without arg filter"
+    (h/reset-components!)
+    (h/config! {:hooks {"spec-check" {:type "preToolCall"
+                                      :matcher {"eca__write_file" {}}
+                                      :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [result* (atom nil)]
+      ;; Should match — empty map = no arg filtering
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/any/path.txt"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (match? {:name "spec-check"} @result*))))
+
+  (testing "map matcher with multiple tools — each with different argsMatchers"
+    (h/reset-components!)
+    (h/config! {:hooks {"spec-check" {:type "postToolCall"
+                                      :matcher {"eca__write_file" {:argsMatchers {"path" [".*\\.allium$"]}}
+                                                "eca__edit_file" {:argsMatchers {"path" [".*\\.allium$"]}}
+                                                "eca__move_file" {}}
+                                      :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [result* (atom nil)]
+      ;; write_file with .allium → match
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :postToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/foo/spec.allium"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (match? {:name "spec-check"} @result*))
+
+      ;; write_file with .txt → no match (argsMatchers filters it out)
+      (reset! result* nil)
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :postToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/foo/spec.txt"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (nil? @result*))
+
+      ;; move_file with any path → match (empty map = no filter)
+      (reset! result* nil)
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :postToolCall
+                                     {:server "eca" :tool-name "move_file"
+                                      :tool-input {"source" "/foo.txt" "destination" "/bar.txt"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (match? {:name "spec-check"} @result*))))
+
+  (testing "map matcher does not match when tool name not in map"
+    (h/reset-components!)
+    (h/config! {:hooks {"spec-check" {:type "preToolCall"
+                                      :matcher {"eca__write_file" {:argsMatchers {"path" [".*\\.allium$"]}}}
+                                      :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [result* (atom nil)]
+      ;; read_file is NOT in matcher map
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "read_file"
+                                      :tool-input {:path "/foo/spec.allium"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (nil? @result*))))
+
+  (testing "string matcher still works (backward compatibility)"
+    (h/reset-components!)
+    (h/config! {:hooks {"my-hook" {:type "preToolCall"
+                                   :matcher "eca__write_file|eca__edit_file"
+                                   :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [result* (atom nil)]
+      ;; Should match
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {:path "/any"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (match? {:name "my-hook"} @result*))))
+
+  (testing "nil matcher matches all (backward compatibility)"
+    (h/reset-components!)
+    (h/config! {:hooks {"my-hook" {:type "preToolCall"
+                                   :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [result* (atom nil)]
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "anything"
+                                      :tool-input {:path "/any"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (match? {:name "my-hook"} @result*))))
+
+  (testing "argsMatchers with multiple patterns — OR within arg"
+    (h/reset-components!)
+    (h/config! {:hooks {"my-hook" {:type "preToolCall"
+                                   :matcher {"eca__write_file" {:argsMatchers {"path" [".*\\.allium$" ".*\\.spec$"]}}}
+                                   :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [result* (atom nil)]
+      ;; .allium → match
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/foo/bar.allium"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (match? {:name "my-hook"} @result*))
+
+      ;; .spec → match
+      (reset! result* nil)
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/foo/bar.spec"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (match? {:name "my-hook"} @result*))
+
+      ;; .txt → no match
+      (reset! result* nil)
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/foo/bar.txt"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (nil? @result*))))
+
+  (testing "argsMatchers with multiple args — AND across args"
+    (h/reset-components!)
+    (h/config! {:hooks {"my-hook" {:type "preToolCall"
+                                   :matcher {"eca__write_file" {:argsMatchers {"path" [".*\\.allium$"]
+                                                                              "original_content" [".*foo.*"]}}}
+                                   :actions [{:type "shell" :shell "echo ok"}]}}})
+    (let [result* (atom nil)]
+      ;; Both args match → match
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/bar.allium"
+                                                   "original_content" "foo bar"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (match? {:name "my-hook"} @result*))
+
+      ;; Only path matches, original_content doesn't → no match
+      (reset! result* nil)
+      (with-redefs [f.hooks/run-shell-cmd (constantly {:exit 0 :out "ok" :err nil})]
+        (f.hooks/trigger-if-matches! :preToolCall
+                                     {:server "eca" :tool-name "write_file"
+                                      :tool-input {"path" "/bar.allium"
+                                                   "original_content" "no match here"}}
+                                     {:on-after-action (set-action-payload result*)}
+                                     (h/db) (h/config)))
+      (is (nil? @result*)))))

--- a/test/eca/features/tools_test.clj
+++ b/test/eca/features/tools_test.clj
@@ -159,7 +159,8 @@
         plan-tool {:name "plan" :server {:name "eca"} :origin :native :require-approval-fn (constantly false)}
         request-tool {:name "request" :server {:name "web"} :origin :mcp}
         download-tool {:name "download" :server {:name "web"} :origin :mcp}
-        all-tools [read-tool write-tool shell-tool plan-tool request-tool download-tool]]
+        web-write-tool {:name "write" :server {:name "web"} :origin :mcp}
+        all-tools [read-tool write-tool shell-tool plan-tool request-tool download-tool web-write-tool]]
     (testing "tool has require-approval-fn which returns true"
       (is (= :ask (f.tools/approval all-tools shell-tool {} {} {} nil))))
     (testing "tool has require-approval-fn which returns false we ignore it"
@@ -174,6 +175,7 @@
       (testing "when matches allow config"
         (is (= :allow (f.tools/approval all-tools request-tool {} {} {:toolCall {:approval {:allow {"web__request" {}}}}} nil)))
         (is (= :allow (f.tools/approval all-tools read-tool {} {} {:toolCall {:approval {:allow {"read" {}}}}} nil)))
+        (is (= :ask (f.tools/approval all-tools web-write-tool {} {} {:toolCall {:approval {:allow {"write" {}}}}} nil)))
         (is (= :allow (f.tools/approval all-tools request-tool {} {} {:toolCall {:approval {:allow {"web" {}}}}} nil)))
         (is (= :allow (f.tools/approval all-tools read-tool {} {} {:toolCall {:approval {:allow {"eca" {}}}}} nil))))
       (testing "when matches ask config"


### PR DESCRIPTION
Add object-form hook matchers keyed by tool selectors, with optional per-tool argsMatchers for preToolCall and postToolCall hooks. Keep legacy string regex matchers working for backwards compatibility.

Preserve hook matcher selector and argument keys during config normalization, share selector matching with tool approval, and update docs/schema/tests for the new matcher shape.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
