### PR TITLE
Detect command and skill args from $ARGN/$N/$ARGS placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Custom commands and skills now expose `:arguments` metadata inferred from their content. Previously they always reported empty arguments.
+- Native `skill-create`, `plugin-install`, and `plugin-uninstall` commands now declare `:required true` on their arguments in the command listing.
+
 ## 0.131.1
 
 - MCP tools that return image content blocks (e.g. an MCP image-generation/edit server) now render those images in the chat UI as `ChatImageContent` and replay them back to the LLM as image inputs on follow-up turns when the model supports vision. Implemented for `openai-responses` (synthetic user-role `input_image` after the `function_call_output`) and `anthropic` (mixed text + image blocks inside `tool_result.content`). `openai-chat` and `ollama` continue to receive a text placeholder until a parallel pattern is implemented there.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1474,7 +1474,7 @@ interface ChatCommand {
     arguments: [{
        name: string;
        description?: string;
-       required: boolean; 
+       required?: boolean;
     }];
 }
 ```

--- a/src/eca/features/commands.clj
+++ b/src/eca/features/commands.clj
@@ -37,15 +37,6 @@
 (defn ^:private normalize-command-name [f]
   (string/lower-case (fs/strip-ext (fs/file-name f))))
 
-(defn ^:private prefixed-command-name
-  "Builds the user-invocation name for a plugin-sourced command.
-   Returns just the plugin name when it equals the command name,
-   otherwise 'plugin:command'."
-  [plugin-name command-name]
-  (if (= plugin-name command-name)
-    plugin-name
-    (str plugin-name ":" command-name)))
-
 (defn ^:private markdown-file? [file]
   (and (not (fs/directory? file))
        (string/ends-with? (string/lower-case (str file)) ".md")))
@@ -60,11 +51,12 @@
   (let [base (normalize-command-name file)
         content (interpolation/replace-dynamic-strings (slurp (str file)) (str (fs/parent file)) nil)]
     (cond-> {:name (if-let [plugin (:plugin opts)]
-                     (prefixed-command-name plugin base)
+                     (shared/prefixed-name plugin base)
                      base)
              :path (str (fs/canonicalize file))
              :type type
-             :content content}
+             :content content
+             :arguments (shared/extract-args-from-content content)}
       (:plugin opts) (assoc :plugin (:plugin opts)))))
 
 (defn ^:private global-file-commands []
@@ -125,8 +117,8 @@
                       {:name "skill-create"
                        :type :native
                        :description "Create a skill considering a user request"
-                       :arguments [{:name "name" :description "The skill name"}
-                                   {:name "prompt" :description "What to consider as this skill content"}]}
+                       :arguments [{:name "name" :description "The skill name" :required true}
+                                   {:name "prompt" :description "What to consider as this skill content" :required true}]}
                       {:name "costs"
                        :type :native
                        :description "Total costs of the current chat session."
@@ -178,23 +170,23 @@
                       {:name "plugin-install"
                        :type :native
                        :description "Install a plugin (e.g. /plugin-install my-plugin or /plugin-install my-plugin@marketplace)"
-                       :arguments [{:name "plugin" :description "Plugin name or plugin@marketplace"}]}
+                       :arguments [{:name "plugin" :description "Plugin name or plugin@marketplace" :required true}]}
                       {:name "plugin-uninstall"
                        :type :native
                        :description "Uninstall a plugin (e.g. /plugin-uninstall my-plugin)"
-                       :arguments [{:name "plugin" :description "Plugin name"}]}]
+                       :arguments [{:name "plugin" :description "Plugin name" :required true}]}]
         custom-cmds (map (fn [custom]
                            {:name (:name custom)
                             :type :custom-prompt
                             :description (:path custom)
-                            :arguments []})
+                            :arguments (:arguments custom)})
                          (custom-commands config (:workspace-folders db)))
         skills-cmds (->> (f.skills/all config (:workspace-folders db))
                          (mapv (fn [skill]
                                  {:name (:name skill)
                                   :type :skill
                                   :description (:description skill)
-                                  :arguments []})))]
+                                  :arguments (:arguments skill)})))]
     (concat mcp-prompts
             eca-commands
             skills-cmds

--- a/src/eca/features/skills.clj
+++ b/src/eca/features/skills.clj
@@ -19,6 +19,7 @@
         {:name name
          :description description
          :body body
+         :arguments (shared/extract-args-from-content body)
          :dir (str (fs/canonicalize (fs/parent skill-file)))}))
     (catch Exception e
       (logger/warn logger-tag (format "Error parsing skill file '%s': %s" (str skill-file) (.getMessage e)))
@@ -39,20 +40,11 @@
     (fs/directory? path) (filter skill-file? (fs/glob path "**" {:follow-links true}))
     :else [path]))
 
-(defn ^:private prefixed-skill-name
-  "Builds the user-invocation name for a plugin skill.
-   Returns just the plugin name when it equals the skill name,
-   otherwise 'plugin:skill'."
-  [plugin-name skill-name]
-  (if (= plugin-name skill-name)
-    plugin-name
-    (str plugin-name ":" skill-name)))
-
 (defn ^:private plugin-skill [plugin file]
   (when-let [skill (skill-file->skill file)]
     (cond-> skill
       plugin (assoc :plugin plugin
-                    :name (prefixed-skill-name plugin (:name skill))))))
+                    :name (shared/prefixed-name plugin (:name skill))))))
 
 (defn ^:private global-skills []
   (keep skill-file->skill

--- a/src/eca/shared.clj
+++ b/src/eca/shared.clj
@@ -63,6 +63,27 @@
           (assoc metadata :body (string/trim (string/join "\n" body-lines)))))
       {:body (string/trim content)})))
 
+(defn extract-args-from-content
+  "Parses command/skill content for $ARGN, $N, $ARGS, and $ARGUMENTS placeholders
+   and returns the corresponding :arguments vector for command metadata.
+   Returns an empty vector when no argument placeholders are found."
+  [content]
+  (if (string/blank? content)
+    []
+    (let [content (str content)
+          nums (keep (fn [[_ n]] (parse-long n))
+                     (re-seq #"\$(?:ARG)?(\d+)" content))
+          has-varargs (some #(string/includes? content %)
+                            ["$ARGS" "$ARGUMENTS"])
+          max-n (when (seq nums) (apply max nums))
+          declared-count (cond
+                           max-n     max-n
+                           has-varargs 1)]
+      (if declared-count
+        (vec (for [i (range 1 (inc declared-count))]
+               {:name (str "arg" i) :required true}))
+        []))))
+
 ;; Walks up from a non-existing path to find the nearest existing ancestor,
 ;; canonicalizes it (resolving symlinks), then re-attaches the missing segments.
 ;; This is needed because workspace roots can be symlinks — for write_file
@@ -115,6 +136,14 @@
 (def line-separator
   "The system's line separator."
   (System/lineSeparator))
+
+(defn prefixed-name
+  "Builds a plugin-prefixed name. Returns the bare name when it
+   equals the plugin name, otherwise 'plugin:name'."
+  [plugin-name capability-name]
+  (if (= plugin-name capability-name)
+    plugin-name
+    (str plugin-name ":" capability-name)))
 
 (defn normalize-api-url [api-url]
   (some-> api-url

--- a/test/eca/features/commands_test.clj
+++ b/test/eca/features/commands_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer [deftest is testing]]
    [eca.features.commands :as f.commands]
    [eca.features.rules :as f.rules]
+   [eca.shared :as shared]
    [eca.test-helper :as h]))
 
 (h/reset-components-before-test)
@@ -112,6 +113,29 @@
                 result (vec (#'f.commands/custom-commands config []))]
             (is (= #{"review" "ship"} (set (map :name result))))
             (is (= #{"Review body" "Ship body"} (set (map :content result)))))))
+
+      (finally
+        (fs/delete-tree tmp-dir)))))
+
+(deftest command-arguments-test
+  (let [tmp-dir (fs/create-temp-dir)]
+    (try
+      (testing "command with $ARG1 placeholder detects arguments"
+        (let [cmd-file (fs/file tmp-dir "greet.md")]
+          (spit cmd-file "Greet $ARG1!")
+          (let [config {:pureConfig true :commands [{:path (str cmd-file)}]}
+                result (vec (#'f.commands/custom-commands config []))]
+            (is (= 1 (count result)))
+            (is (= "greet" (:name (first result))))
+            (is (= [{:name "arg1" :required true}]
+                   (:arguments (first result)))))))
+
+      (testing "command without placeholders has empty arguments"
+        (let [cmd-file (fs/file tmp-dir "simple.md")]
+          (spit cmd-file "Simple body")
+          (let [config {:pureConfig true :commands [{:path (str cmd-file)}]}
+                result (vec (#'f.commands/custom-commands config []))]
+            (is (= [] (:arguments (first result)))))))
 
       (finally
         (fs/delete-tree tmp-dir)))))
@@ -305,3 +329,49 @@
                                                   :metrics (h/metrics)})
             text (get-in result [:chats "chat-1" :messages 0 :content 0 :text])]
         (is (= "No rules available for the current agent and model." text))))))
+
+(deftest extract-args-from-content-test
+  (testing "detects $ARG1 placeholder"
+    (is (= [{:name "arg1" :required true}]
+           (shared/extract-args-from-content "Respond with $ARG1"))))
+
+  (testing "detects multiple $ARGn placeholders"
+    (is (= [{:name "arg1" :required true}
+            {:name "arg2" :required true}
+            {:name "arg3" :required true}]
+           (shared/extract-args-from-content "First:$ARG1 Second:$ARG2 Third:$ARG3"))))
+
+  (testing "detects $ARGS without $ARGn"
+    (is (= [{:name "arg1" :required true}]
+           (shared/extract-args-from-content "Use all args: $ARGS"))))
+
+  (testing "detects $ARGUMENTS without $ARGn"
+    (is (= [{:name "arg1" :required true}]
+           (shared/extract-args-from-content "Process $ARGUMENTS here"))))
+
+  (testing "detects Claude Code style $1 and $2"
+    (is (= [{:name "arg1" :required true}
+            {:name "arg2" :required true}]
+           (shared/extract-args-from-content "First:$1 Second:$2"))))
+
+  (testing "uses max of all placeholder styles"
+    (is (= [{:name "arg1" :required true}]
+           (shared/extract-args-from-content "$ARG1 $1"))))
+
+  (testing "returns empty vector when no placeholders present"
+    (is (= []
+           (shared/extract-args-from-content "No placeholders here"))))
+
+  (testing "returns empty vector for nil/blank content"
+    (is (= [] (shared/extract-args-from-content nil)))
+    (is (= [] (shared/extract-args-from-content ""))))
+
+  (testing "$ARGn takes precedence over $ARGS for argument count"
+    (is (= [{:name "arg1" :required true}]
+           (shared/extract-args-from-content "Single:$ARG1 All:$ARGS"))))
+
+  (testing "detects $ARG10 and declares all args up to 10"
+    (let [result (shared/extract-args-from-content "Use $ARG10")]
+      (is (= 10 (count result)))
+      (is (= {:name "arg1" :required true} (first result)))
+      (is (= {:name "arg10" :required true} (last result))))))


### PR DESCRIPTION
Command and skill files previously exposed hardcoded :arguments [] in the command listing regardless of their content. Now they scan for $ARG1, $1, $ARGS, and $ARGUMENTS placeholders and produce matching :arguments metadata so clients can prompt users correctly.

Native commands that require arguments (skill-create, plugin-install, plugin-uninstall) are now marked :required true.

Deduplicate prefixed-command-name and prefixed-skill-name into shared/prefixed-name. Fix protocol docs to mark required as optional.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
