### PR TITLE
Update broken documentation link in `--help` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- Fix documentation link in `--help` output
 ## 0.131.1
 
 - MCP tools that return image content blocks (e.g. an MCP image-generation/edit server) now render those images in the chat UI as `ChatImageContent` and replay them back to the LLM as image inputs on follow-up turns when the model supports vision. Implemented for `openai-responses` (synthetic user-role `input_image` after the `function_call_output`) and `anthropic` (mixed text + image blocks inside `tool_result.content`). `openai-chat` and `ollama` continue to receive a text placeholder until a parallel pattern is implemented there.

--- a/src/eca/main.clj
+++ b/src/eca/main.clj
@@ -33,7 +33,7 @@
         "Available commands:"
         "  server        Start eca as server, listening to stdin."
         ""
-        "See https://eca.dev/settings/ for detailed documentation."]
+        "See https://eca.dev/config/introduction/ for detailed documentation."]
        (string/join \newline)))
 
 (defn ^:private error-msg [errors]


### PR DESCRIPTION
Link in `--help` output (https://eca.dev/settings/) was giving 404, replaced it with closest documentation link that I found from the site. 

- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
