### PR TITLE
Add base directory resolution hint to skill tool description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Improve skill tool description to resolve file paths and scripts mentioned in skill content against the skill's base directory.
+
 ## 0.131.1
 
 - MCP tools that return image content blocks (e.g. an MCP image-generation/edit server) now render those images in the chat UI as `ChatImageContent` and replay them back to the LLM as image inputs on follow-up turns when the model supports vision. Implemented for `openai-responses` (synthetic user-role `input_image` after the `function_call_output`) and `anthropic` (mixed text + image blocks inside `tool_result.content`). `openai-chat` and `ollama` continue to receive a text placeholder until a parallel pattern is implemented there.

--- a/resources/prompts/tools/skill.md
+++ b/resources/prompts/tools/skill.md
@@ -1,3 +1,4 @@
 Load a skill to get detailed instructions for a specific task.
 Skills provide specialized knowledge and step-by-step guidance.
 Use this when a task matches an available skill's description.
+After loading, resolve any file paths, scripts, or relative references mentioned in the skill content against the provided base directory.


### PR DESCRIPTION
The skill tool description didn't tell the LLM that file paths, scripts, or relative references inside the loaded skill content should be resolved against the skill's base directory. This caused the LLM to call scripts with wrong paths (usually CWD instead of the skill directory). Update the description to make this explicit.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
