### PR TITLE
Fix OpenAI OAuth web search and image generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix OpenAI OAuth requests dropping built-in web search and image generation tools, and avoid replaying web search history artifacts on follow-up turns.
+
 ## 0.133.1
 
 - Support client-generated chat ids: clients may now create the `chatId` themselves and send it on the first `chat/prompt`. eca-emacs#231.

--- a/src/eca/llm_providers/openai.clj
+++ b/src/eca/llm_providers/openai.clj
@@ -152,6 +152,8 @@
                                     [{:type "summary_text"
                                       :text (:text content)}])
                          :encrypted_content (:external-id content)}]
+              "server_tool_use" []
+              "server_tool_result" []
               [(-> msg
                    (dissoc :content-id)
                    (update :content (fn [c]
@@ -175,7 +177,7 @@
                                               c)))))]))
           messages))
 
-(defn ^:private ->tools [tools web-search image-generation codex?]
+(defn ^:private ->tools [tools web-search image-generation]
   (cond->
    (mapv (fn [tool]
            {:type "function"
@@ -183,22 +185,22 @@
             :description (:description tool)
             :parameters (:parameters tool)})
          tools)
-    (and web-search (not codex?)) (conj {:type "web_search_preview"})
-    (and image-generation (not codex?)) (conj {:type "image_generation" :output_format "png"})))
+    web-search (conj {:type "web_search"})
+    image-generation (conj {:type "image_generation" :output_format "png"})))
 
 (defn create-response! [{:keys [model user-messages instructions reason? supports-image? api-key api-url url-relative-path
                                 max-output-tokens past-messages tools web-search image-generation extra-payload extra-headers
                                 auth-type account-id http-client prompt-cache-key]}
                         {:keys [on-message-received on-error on-prepare-tool-call on-tools-called on-reason on-usage-updated
                                 on-server-web-search on-server-image-generation] :as callbacks}]
-  (let [codex? (= :auth/oauth auth-type)
+  (let [oauth? (= :auth/oauth auth-type)
         input (concat (normalize-messages past-messages supports-image?)
                       (normalize-messages user-messages supports-image?))
-        tools (->tools tools web-search image-generation codex?)
+        tools (->tools tools web-search image-generation)
         body (merge
               (assoc-some
                {:model model
-                :input (if codex?
+                :input (if oauth?
                          (concat [{:role "system" :content instructions}] input)
                          input)
                 :prompt_cache_key (or prompt-cache-key
@@ -212,7 +214,7 @@
                              {:effort "medium"
                               :summary "auto"})
                 :stream true}
-               :max_output_tokens (when-not codex? max-output-tokens)
+               :max_output_tokens (when-not oauth? max-output-tokens)
                :parallel_tool_calls (:parallel_tool_calls extra-payload))
               extra-payload)
         tool-call-by-item-id* (atom {})
@@ -345,7 +347,7 @@
                      {:rid (llm-util/gen-rid)
                       :body (assoc body
                                    :input (normalize-messages new-messages supports-image?)
-                                   :tools (->tools tools web-search image-generation codex?))
+                                   :tools (->tools tools web-search image-generation))
                       :api-url api-url
                       :url-relative-path url-relative-path
                       :api-key (or fresh-api-key api-key)

--- a/test/eca/llm_providers/openai_test.clj
+++ b/test/eca/llm_providers/openai_test.clj
@@ -257,7 +257,19 @@
     (is (= []
            (#'llm-providers.openai/normalize-messages
             [{:role "image_generation_call" :content {:base64 "DDD"}}]
-            false)))))
+            false))))
+  (testing "server web search history artifacts are skipped on replay"
+    (is (match?
+         [{:role "assistant"
+           :content [{:type "output_text" :text "Found the answer."}]}]
+         (#'llm-providers.openai/normalize-messages
+          [{:role "server_tool_use"
+            :content {:id "ws_1" :name "web_search" :input {:query "latest news"}}}
+           {:role "server_tool_result"
+            :content {:tool-use-id "ws_1" :raw-content nil}}
+           {:role "assistant"
+            :content [{:type :text :text "Found the answer."}]}]
+          true)))))
 
 (defn- base-provider-params []
   {:model "gpt-test"
@@ -382,25 +394,43 @@
                      :output "ok\n"}
                     (first out)))))))
 
-(deftest ->tools-image-generation-test
-  (testing "image_generation tool is appended when flag is on and not on codex path"
+(deftest ->tools-built-in-tools-test
+  (testing "image_generation tool is appended when flag is on"
     (is (match?
          [{:type "image_generation" :output_format "png"}]
-         (#'llm-providers.openai/->tools [] false true false))))
+         (#'llm-providers.openai/->tools [] false true))))
   (testing "image_generation tool is NOT appended when flag is off"
     (is (= []
-           (#'llm-providers.openai/->tools [] false false false))))
-  (testing "image_generation tool is NOT appended on codex path even if flag is on"
-    (is (= []
-           (#'llm-providers.openai/->tools [] false true true))))
+           (#'llm-providers.openai/->tools [] false false))))
   (testing "image_generation tool sits alongside web_search and function tools"
     (is (match?
          [{:type "function" :name "eca__foo"}
-          {:type "web_search_preview"}
+          {:type "web_search"}
           {:type "image_generation" :output_format "png"}]
          (#'llm-providers.openai/->tools
           [{:full-name "eca__foo" :description "d" :parameters {}}]
-          true true false)))))
+          true true)))))
+
+(deftest create-response-oauth-preserves-built-in-tools-test
+  (testing "OAuth requests keep web_search and image_generation when capabilities are enabled"
+    (let [requests* (atom [])]
+      (with-redefs [llm-providers.openai/base-responses-request!
+                    (fn [{:keys [on-stream] :as opts}]
+                      (swap! requests* conj opts)
+                      (on-stream "response.completed"
+                                 {:response {:output []
+                                             :usage {:input_tokens 0 :output_tokens 0}
+                                             :status "completed"}}))]
+        (llm-providers.openai/create-response!
+         (assoc (base-provider-params)
+                :auth-type :auth/oauth
+                :web-search true
+                :image-generation true)
+         (base-callbacks {}))
+        (is (match? [{:type "function"}
+                     {:type "web_search"}
+                     {:type "image_generation" :output_format "png"}]
+                    (get-in (first @requests*) [:body :tools])))))))
 
 (deftest create-response-image-generation-tool-on-request-test
   (testing "request body includes image_generation tool when :image-generation is true"


### PR DESCRIPTION
The OpenAI built-in web-search and image-generation didn't work when authentication with OAuth, because the authentication method flag was used to drop this feature.

New issues arised as the newer models required the `web_search` tool instead of the legacy `web_search_preview` tool. Also, the server tried to send web-search artefacts back to OpenAi when continuing the conversation, which caused an API error.

This PR should fix these issues. I got openai/gpt-5.5 and openai/gpt-5.4 models with OAuth to search the web and generate images. openai/gpt-5.3-codex doesn't see the tools as per design. I couldn't verify if some older models using API key authentication might still rely on the `web_search_preview` tool.

---- 

## AI Summary 
- Preserve OpenAI built-in web search and image generation tools when using OAuth authentication, relying on model capabilities instead of auth type to decide tool availability.
- Use the current OpenAI Responses API `web_search` tool type instead of the legacy `web_search_preview` type.
- Skip OpenAI server web-search history artifacts during replay so follow-up turns after web search do not crash.

## Verification
- `clojure -M:test --focus eca.llm-providers.openai-test`
- Manual test with a locally built ECA server confirmed OpenAI OAuth web search works across follow-up turns.
- `clj-kondo --lint src/eca/llm_providers/openai.clj test/eca/llm_providers/openai_test.clj` could not be run locally because `clj-kondo` is not installed in this environment.

🤖 Generated with [eca](https://eca.dev)