### PR TITLE
Fix subagent chat ID validation regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix subagent spawning being rejected by reserved server-managed chat ids.
+
 ## 0.133.1
 
 - Support client-generated chat ids: clients may now create the `chatId` themselves and send it on the first `chat/prompt`. eca-emacs#231.

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -1246,6 +1246,12 @@
 
 (def ^:private max-client-chat-id-length 256)
 
+(defn ^:private server-managed-subagent-chat-id?
+  [db chat-id]
+  (and (string? chat-id)
+       (string/starts-with? chat-id "subagent-")
+       (some? (get-in db [:chats chat-id :subagent]))))
+
 (defn validate-client-chat-id
   "Validates a client-supplied chat id. Returns nil when valid, otherwise an
    error message string.
@@ -1275,7 +1281,8 @@
 (defn prompt
   [{:keys [message agent behavior chat-id contexts variant trust] :as params} db* messenger config metrics]
   (let [provided-chat-id chat-id
-        invalid-id-reason (when (some? provided-chat-id)
+        invalid-id-reason (when (and (some? provided-chat-id)
+                                     (not (server-managed-subagent-chat-id? @db* provided-chat-id)))
                             (validate-client-chat-id provided-chat-id))]
     (if invalid-id-reason
       (do (logger/warn logger-tag "Rejected chat/prompt with invalid chat-id"

--- a/test/eca/features/chat_test.clj
+++ b/test/eca/features/chat_test.clj
@@ -1403,6 +1403,19 @@
       (is (match? {:chat-id "subagent-foo" :status :error} resp))
       (is (= {} (:chats (h/db))))
       (is (nil? (:chat-opened (h/messages))))))
+  (testing "Server-managed subagent chat-id is accepted"
+    (h/reset-components!)
+    (let [chat-id "subagent-foo"]
+      (swap! (h/db*) assoc-in [:chats chat-id] {:id chat-id :subagent {:mode "subagent"}})
+      (is (= {:chat-id chat-id}
+             (prompt!
+              {:message "hi" :chat-id chat-id}
+              {:all-tools-mock (constantly [])
+               :api-mock
+               (fn [{:keys [on-first-response-received on-message-received]}]
+                 (on-first-response-received {:type :text :text "ok"})
+                 (on-message-received {:type :text :text "ok"})
+                 (on-message-received {:type :finish}))})))))
   (testing "Excessively long chat-id is rejected"
     (h/reset-components!)
     (let [too-long (apply str (repeat 257 "a"))


### PR DESCRIPTION
Sub-agent spawning stopped working for me in the latest release, `0.133.1`. I tested these changes locally, and sub-agent spawning works again with this fix.

The summary below is AI-generated.

## Summary

Fix a regression where `spawn_agent` was rejected by `chat/prompt` because server-managed subagent chat IDs use the reserved `subagent-` prefix.

The validation still rejects client-created `subagent-*` IDs, but allows an existing chat that has already been seeded as a server-managed subagent.

## Test plan

- `clojure -M:test --focus eca.features.chat-test/prompt-rejects-invalid-client-chat-id-test`
- `clojure -M:test --focus eca.features.tools.agent-test`

## Checklist

- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.

🤖 Generated with [eca](https://eca.dev)