### PR TITLE
Add read-chat CLI command and centralize message sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- New `eca read-chat` CLI command for streaming raw chat DB cache records as JSONL.
+
 ## 0.136.0
 
 - Anthropic Opus 4.8: send volatile (dynamic) instructions as a mid-conversation system message so the cached conversation history isn't invalidated each turn.

--- a/docs/read-chat.md
+++ b/docs/read-chat.md
@@ -1,0 +1,204 @@
+---
+description: "Stream raw ECA chat history from the DB cache as JSONL: list chats, filter messages by time or role."
+---
+
+# read-chat
+
+Inspect ECA's chat database offline by reading `db.transit.json` directly. No running server is required.
+
+Output is always **raw JSONL** (one JSON object per line) in the persisted internal shape, making it suitable for debugging, export, and programmatic processing.
+
+## Quick start
+
+```bash
+# List all chats (newest first)
+eca read-chat --db-cache-path ~/.cache/eca/db.transit.json
+
+# Resolve the cache from the session's workspace folders
+eca read-chat --workspace ~/Code/Clojure/eca --workspace ~/Code/Clojure/eca-worktrees/add-read-chat-command
+
+# Stream raw messages from a specific chat
+eca read-chat --db-cache-path ~/.cache/eca/db.transit.json --chat-id <chat-id>
+
+# Last 10 user messages from the past hour
+eca read-chat --db-cache-path ~/.cache/eca/db.transit.json \
+  --chat-id <chat-id> --since 1h --role user | tail -n 10
+```
+
+## Modes
+
+### Listing mode (no `--chat-id`)
+
+Prints one summary object per chat, sorted by `:updated-at` descending. Fields: `id`, `title`, `status`, `model`, `created-at`, `updated-at`, `user-prompt-count`.
+
+`--since`/`--until` filter by chat `:updated-at`.
+
+### Detail mode (`--chat-id`)
+
+Prints one message object per line in chronological order. Fields include `role`, `content`, `content-id`, `created-at`, and any other persisted fields.
+
+`--since`/`--until` filter by message `:created-at`.
+
+## Options
+
+`read-chat` accepts **options only**; positional arguments are rejected.
+
+Provide exactly one input source: `--db-cache-path` or one or more `--workspace` paths.
+
+| Option | Description |
+|--------|-------------|
+| `--db-cache-path <PATH>` | Path to `db.transit.json`. |
+| `--workspace <PATH>` | Workspace folder; repeat in the original session order. |
+| `--chat-id <ID>` | Focus on a chat; omit to list all chats. |
+| `--role <ROLE>` | Filter messages by exact `role` string (requires `--chat-id`). |
+| `--since <DATE>` | Start date (inclusive). |
+| `--until <DATE>` | End date (exclusive). |
+| `-h`, `--help` | Print help. |
+
+### Role values
+
+Common `--role` filters: `user`, `assistant`, `tool_call`, `tool_call_output`, `reason`, `server_tool_use`, `server_tool_result`, `image_generation_call`, `compact_marker`, `flag`.
+
+## Message content shape
+
+- Plain text may be a string.
+- Structured content is often an array like `[{"type":"text","text":"..."}]`.
+- `tool_call`: `content` map with `id`, `name`, `arguments`, `server`, `full-name`, `summary`.
+- `tool_call_output`: `content` map with `id`, `name`, `error`, `output`, `total-time-ms`.
+
+Tool calls and results share the same `content.id`.
+
+## Date formats
+
+| Format | Example | Meaning |
+|--------|---------|---------|
+| Relative | `30m`, `2h`, `1d` | Minutes/hours/days ago |
+| Date | `2025-01-01` | Midnight UTC |
+| Instant | `2025-01-01T14:30:00Z` | Full ISO-8601 |
+
+### Messages without timestamps
+
+Messages created before `:created-at` tracking was added lack timestamps. When filtering by date, they are **excluded** and a stderr warning reports the drop count.
+
+## Scripting examples
+
+=== "Last 10 messages"
+
+    ```bash
+    eca read-chat --db-cache-path ~/.cache/eca/db.transit.json \
+      --chat-id abc | tail -n 10
+    ```
+
+=== "Count messages"
+
+    ```bash
+    eca read-chat --db-cache-path ~/.cache/eca/db.transit.json \
+      --chat-id abc | wc -l
+    ```
+
+=== "Extract user text"
+
+    ```bash
+    eca read-chat --db-cache-path ~/.cache/eca/db.transit.json \
+      --chat-id abc --role user | \
+      jq -r '
+        def content_text:
+          if type == "string" then .
+          elif type == "array" then
+            map(
+              if .type == "text" then .text // empty
+              elif .type == "image" then "[Image: " + (."media-type" // "unknown") + "]"
+              else empty
+              end
+            ) | join("\n")
+          else empty
+          end;
+        .content | content_text
+      '
+    ```
+
+=== "Extract assistant text"
+
+    ```bash
+    eca read-chat --db-cache-path ~/.cache/eca/db.transit.json \
+      --chat-id abc --role assistant | \
+      jq -r '.content[]? | select(.type == "text") | .text'
+    ```
+
+=== "List tool calls"
+
+    ```bash
+    eca read-chat --db-cache-path ~/.cache/eca/db.transit.json \
+      --chat-id abc --role tool_call | \
+      jq -c '.content | {id, name, input: .arguments, summary, server, full_name: ."full-name"}'
+    ```
+
+=== "List tool outputs"
+
+    ```bash
+    eca read-chat --db-cache-path ~/.cache/eca/db.transit.json \
+      --chat-id abc --role tool_call_output | \
+      jq -c '
+        .content
+        | {
+            tool_use_id: .id,
+            name,
+            is_error: .error,
+            total_time_ms: ."total-time-ms",
+            output_text: ((.output.contents // []) | map(select(.type == "text") | .text // empty) | join("\n"))
+          }
+      '
+    ```
+
+=== "Find chats by model"
+
+    ```bash
+    eca read-chat --db-cache-path ~/.cache/eca/db.transit.json | \
+      jq -c 'select(.model | contains("claude"))'
+    ```
+
+=== "Count user prompts"
+
+    ```bash
+    eca read-chat --db-cache-path ~/.cache/eca/db.transit.json | \
+      jq '{id: .id, count: .["user-prompt-count"]}'
+    ```
+
+=== "Export a chat"
+
+    ```bash
+    eca read-chat --db-cache-path ~/.cache/eca/db.transit.json \
+      --chat-id abc > chat-export.jsonl
+    ```
+
+=== "Recent chats, pretty-printed"
+
+    ```bash
+    eca read-chat --db-cache-path ~/.cache/eca/db.transit.json --since 1d | \
+      jq '{title, model, updated_at: .["updated-at"]}'
+    ```
+
+## DB version mismatch
+
+If the file was written by a different ECA version, a warning is printed:
+
+```text
+Warning: DB version mismatch. File has version <old>, expected <current>. Output may be incomplete.
+```
+
+The command still proceeds.
+
+## Errors
+
+| Error | Cause |
+|-------|-------|
+| Missing required input source | Pass `--db-cache-path` or `--workspace`. |
+| Conflicting input sources | Use `--db-cache-path` **or** `--workspace`, not both. |
+| Unknown option / unexpected argument | Only named options are accepted. |
+| Invalid role usage | `--role` requires `--chat-id`. |
+| Missing DB file | Check the path or workspace order. |
+| Read/parse error | File may be locked by the running server or corrupted. |
+| Chat not found | Use listing mode to find valid IDs. |
+| Invalid date format | Use relative (`2h`, `30m`, `1d`) or ISO-8601. |
+
+All errors/warnings go to **stderr**; JSONL goes to **stdout**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Features:
     - Features: features.md
     - Workflows: workflows.md
+    - Read Chat CLI: read-chat.md
   - Install:
     - install.md
   - Configuration:

--- a/src/eca/db.clj
+++ b/src/eca/db.clj
@@ -75,7 +75,8 @@
                         :prompt-cache ::any-map
                         :messages [{:role (or "user" "assistant" "tool_call" "tool_call_output" "reason" "compact_marker" "flag" "server_tool_use" "server_tool_result")
                                     :content (or :string [::any-map]) ;; string for simple text, map/vector for structured content
-                                    :content-id :string}]
+                                    :content-id :string
+                                    :created-at :number}]
                         :task {:next-id :number
                                :active-summary (or :string nil)
                                :tasks [{:id :number
@@ -161,14 +162,20 @@
 (defn ^:private transit-global-by-workspaces-db-file [workspaces]
   (cache/workspace-cache-file workspaces "db.transit.json" shared/uri->filename))
 
+(defn read-transit-file
+  "Read and return the transit+json data from a cache file.
+   Returns nil when the file does not exist. Throws on I/O or parse errors."
+  [^java.io.File cache-file]
+  (when (fs/exists? cache-file)
+    (with-open [is (io/input-stream cache-file)]
+      (transit/read (transit/reader is :json)))))
+
 (defn ^:private read-cache [cache-file metrics]
   (try
     (metrics/task metrics :db/read-cache
-      (if (fs/exists? cache-file)
-        (let [cache (with-open [is (io/input-stream cache-file)]
-                      (transit/read (transit/reader is :json)))]
-          (when (= version (:version cache))
-            cache))
+      (if-let [cache (read-transit-file cache-file)]
+        (when (= version (:version cache))
+          cache)
         (logger/info logger-tag (str "No existing DB cache found for " cache-file))))
     (catch Throwable e
       (logger/error logger-tag "Could not load global cache from DB" e))))

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -678,12 +678,13 @@
             ;; toolu_*/call_* tool ids) the new provider would reject. #209
             current-api (:api (llm-api/provider->api-handler provider model config))
             add-to-history! (fn [{:keys [role content] :as msg}]
-                              (let [tagged (if (and current-api
+                              (let [with-ts (update msg :created-at #(or % (System/currentTimeMillis)))
+                                    tagged (if (and current-api
                                                     (map? content)
                                                     (#{"reason" "tool_call" "tool_call_output"
                                                        "server_tool_use" "server_tool_result"} role))
-                                             (assoc msg :content (assoc content :api current-api))
-                                             msg)]
+                                             (assoc with-ts :content (assoc content :api current-api))
+                                             with-ts)]
                                 (swap! db* update-in [:chats chat-id :messages] (fnil conj []) tagged)
                                 ;; Persist after meaningful history mutations so a
                                 ;; long-running chat is recoverable mid-loop even if
@@ -1622,7 +1623,7 @@
         insert-idx (find-last-message-idx messages content-id)]
     (when insert-idx
       (let [flag-id (str (random-uuid))
-            flag-msg {:role "flag" :content {:text text} :content-id flag-id}
+            flag-msg {:role "flag" :content {:text text} :content-id flag-id :created-at (System/currentTimeMillis)}
             insert-after (inc insert-idx)
             new-messages (into (subvec messages 0 insert-after)
                                (cons flag-msg (subvec messages insert-after)))]

--- a/src/eca/llm_api.clj
+++ b/src/eca/llm_api.clj
@@ -21,6 +21,7 @@
    [eca.llm-providers.z-ai]
    [eca.llm-util :as llm-util]
    [eca.logger :as logger]
+   [eca.message-sanitize :as message-sanitize]
    [eca.shared :as shared]))
 
 (set! *warn-on-reflection* true)
@@ -167,7 +168,8 @@
 
 (defn sanitize-past-messages-for-api
   "Drops history entries whose opaque provider-specific ids would make the
-   request invalid under `target-api`. Returns a map:
+   request invalid under `target-api`, then strips internal-only top-level
+   message metadata before provider serialization. Returns a map:
      :messages      - sanitized past-messages vector
      :dropped-count - number of entries removed
      :dropped-apis  - set of origin apis whose entries were dropped
@@ -176,7 +178,7 @@
   [target-api past-messages]
   (let [past (vec past-messages)
         incompatible? (partial entry-incompatible-with-api? target-api)
-        kept (filterv (complement incompatible?) past)
+        kept (into [] (comp (remove incompatible?) (map message-sanitize/strip-internal-message-fields)) past)
         dropped (filterv incompatible? past)]
     {:messages kept
      :dropped-count (count dropped)
@@ -221,6 +223,7 @@
         {past-messages :messages
          sanitized-dropped-count :dropped-count
          sanitized-dropped-apis :dropped-apis} (sanitize-past-messages-for-api (:api api-handler) past-messages)
+        user-messages (message-sanitize/sanitize-outbound-messages user-messages)
         _ (when (and on-history-sanitized (pos? sanitized-dropped-count))
             (try
               (on-history-sanitized {:dropped-count sanitized-dropped-count

--- a/src/eca/llm_providers/anthropic.clj
+++ b/src/eca/llm_providers/anthropic.clj
@@ -9,6 +9,7 @@
    [eca.features.providers :as f.providers]
    [eca.llm-util :as llm-util]
    [eca.logger :as logger]
+   [eca.message-sanitize :as message-sanitize]
    [eca.oauth :as oauth]
    [eca.shared :as shared :refer [assoc-some join-api-url multi-str]]
    [hato.client :as http]
@@ -253,7 +254,6 @@
                             :content (:raw-content content)}]})
 
             (-> msg
-                (dissoc :content-id)
                 (update :content (fn [c]
                                    (if (string? c)
                                      (string/trim c)
@@ -523,6 +523,7 @@
                                                                (vals @content-block*))]
                                                (when-let [{:keys [new-messages tools fresh-api-key]} (on-tools-called tool-calls)]
                                                  (let [messages (-> new-messages
+                                                                    message-sanitize/sanitize-outbound-messages
                                                                     group-parallel-tool-calls
                                                                     (normalize-messages supports-image?)
                                                                     merge-adjacent-assistants

--- a/src/eca/llm_providers/ollama.clj
+++ b/src/eca/llm_providers/ollama.clj
@@ -5,6 +5,7 @@
    [eca.client-http :as client]
    [eca.llm-util :as llm-util]
    [eca.logger :as logger]
+   [eca.message-sanitize :as message-sanitize]
    [eca.shared :refer [deep-merge join-api-url]]
    [hato.client :as http]))
 
@@ -170,15 +171,16 @@
                              (if-let [tool-call (get @tool-calls* rid)]
                                  ;; TODO support multiple tool calls
                                (when-let [{:keys [new-messages tools]} (on-tools-called [tool-call])]
-                                 (swap! tool-calls* dissoc rid)
-                                 (base-chat-request!
-                                  {:rid (llm-util/gen-rid)
-                                   :url url
-                                   :body (assoc body :messages (normalize-messages new-messages)
-                                                :tools (->tools tools))
-                                   :extra-headers extra-headers
-                                   :on-error on-error
-                                   :on-stream handle-stream}))
+                                 (let [new-messages (message-sanitize/sanitize-outbound-messages new-messages)]
+                                   (swap! tool-calls* dissoc rid)
+                                   (base-chat-request!
+                                    {:rid (llm-util/gen-rid)
+                                     :url url
+                                     :body (assoc body :messages (normalize-messages new-messages)
+                                                  :tools (->tools tools))
+                                     :extra-headers extra-headers
+                                     :on-error on-error
+                                     :on-stream handle-stream})))
                                (on-message-received {:type :finish
                                                      :finish-reason done_reason}))
 

--- a/src/eca/llm_providers/openai.clj
+++ b/src/eca/llm_providers/openai.clj
@@ -9,6 +9,7 @@
    [eca.features.providers :as f.providers]
    [eca.llm-util :as llm-util]
    [eca.logger :as logger]
+   [eca.message-sanitize :as message-sanitize]
    [eca.oauth :as oauth]
    [eca.shared :refer [assoc-some join-api-url multi-str]]
    [hato.client :as http]
@@ -164,27 +165,26 @@
                              :encrypted_content (:external-id content)}])
                 "server_tool_use" []
                 "server_tool_result" []
-              [(-> msg
-                   (dissoc :content-id)
-                   (update :content (fn [c]
-                                      (if (string? c)
-                                        c
-                                        (keep #(case (name (:type %))
+                [(-> msg
+                     (update :content (fn [c]
+                                        (if (string? c)
+                                          c
+                                          (keep #(case (name (:type %))
 
-                                                 "text"
-                                                 (assoc % :type (if (= "user" role)
-                                                                  "input_text"
-                                                                  "output_text"))
+                                                   "text"
+                                                   (assoc % :type (if (= "user" role)
+                                                                    "input_text"
+                                                                    "output_text"))
 
-                                                 "image"
-                                                 (when supports-image?
-                                                   {:type "input_image"
-                                                    :image_url (format "data:%s;base64,%s"
-                                                                       (:media-type %)
-                                                                       (:base64 %))})
+                                                   "image"
+                                                   (when supports-image?
+                                                     {:type      "input_image"
+                                                      :image_url (format "data:%s;base64,%s"
+                                                                         (:media-type %)
+                                                                         (:base64 %))})
 
-                                                 %)
-                                              c)))))])))
+                                                   %)
+                                                c)))))])))
           messages))
 
 (defn ^:private ->tools [tools web-search image-generation]
@@ -353,21 +353,22 @@
                                      :input-cache-read-tokens input-cache-read-tokens}))
                 (if (seq tool-calls)
                   (when-let [{:keys [new-messages tools fresh-api-key provider-auth]} (on-tools-called tool-calls)]
-                    (reset! tool-call-by-item-id* {})
-                    (base-responses-request!
-                     {:rid (llm-util/gen-rid)
-                      :body (assoc body
-                                   :input (normalize-messages new-messages supports-image?)
-                                   :tools (->tools tools web-search image-generation))
-                      :api-url api-url
-                      :url-relative-path url-relative-path
-                      :api-key (or fresh-api-key api-key)
-                      :account-id (or (:account-id provider-auth) account-id)
-                      :http-client http-client
-                      :extra-headers extra-headers
-                      :auth-type auth-type
-                      :on-error on-error
-                      :on-stream handle-stream}))
+                    (let [new-messages (message-sanitize/sanitize-outbound-messages new-messages)]
+                      (reset! tool-call-by-item-id* {})
+                      (base-responses-request!
+                       {:rid (llm-util/gen-rid)
+                        :body (assoc body
+                                     :input (normalize-messages new-messages supports-image?)
+                                     :tools (->tools tools web-search image-generation))
+                        :api-url api-url
+                        :url-relative-path url-relative-path
+                        :api-key (or fresh-api-key api-key)
+                        :account-id (or (:account-id provider-auth) account-id)
+                        :http-client http-client
+                        :extra-headers extra-headers
+                        :auth-type auth-type
+                        :on-error on-error
+                        :on-stream handle-stream})))
                   (on-message-received {:type :finish
                                         :finish-reason (-> data :response :status)})))
 

--- a/src/eca/llm_providers/openai_chat.clj
+++ b/src/eca/llm_providers/openai_chat.clj
@@ -6,6 +6,7 @@
    [eca.client-http :as client]
    [eca.llm-util :as llm-util]
    [eca.logger :as logger]
+   [eca.message-sanitize :as message-sanitize]
    [eca.shared :refer [assoc-some deep-merge join-api-url]]
    [hato.client :as http]))
 
@@ -525,7 +526,8 @@
                                        tool-calls))
         on-tools-called-wrapper (fn on-tools-called-wrapper [tools-to-call on-tools-called handle-response]
                                   (when-let [{:keys [new-messages tools fresh-api-key]} (on-tools-called tools-to-call)]
-                                    (let [pruned-messages (prune-history new-messages reasoning-history)
+                                    (let [new-messages (message-sanitize/sanitize-outbound-messages new-messages)
+                                          pruned-messages (prune-history new-messages reasoning-history)
                                           new-messages-list (vec (concat
                                                                   system-messages
                                                                   (normalize-messages pruned-messages supports-image? think-tag-start think-tag-end)))

--- a/src/eca/main.clj
+++ b/src/eca/main.clj
@@ -9,14 +9,17 @@
    [eca.config :as config]
    [eca.logger :as logger]
    [eca.network :as network]
+   [eca.read-chat :as read-chat]
    [eca.server :as server]))
 
 (set! *warn-on-reflection* true)
 
 (defn ^:private exit [status msg]
-  (when msg
-    (println msg))
-  (System/exit (or status 1)))
+  (let [status (or status 1)]
+    (when msg
+      (binding [*out* (if (zero? status) *out* *err*)]
+        (println msg)))
+    (System/exit status)))
 
 (defn ^:private version []
   (str "eca " (config/eca-version)))
@@ -32,13 +35,28 @@
         ""
         "Available commands:"
         "  server        Start eca as server, listening to stdin."
+        "  read-chat     Stream chat history from the DB cache as JSONL."
         ""
         "See https://eca.dev/config/introduction/ for detailed documentation."]
        (string/join \newline)))
 
+(defn ^:private cli-error-msg [error]
+  (if (map? error)
+    (let [{:keys [cause msg option value]} error
+          option-name (some->> option name (str "--"))]
+      (case cause
+        :require (str "Missing required option " option-name)
+        :restrict (str "Unknown option " option-name)
+        :coerce (if (true? value)
+                  (str "Missing value for " option-name)
+                  (str "Invalid value for " option-name ": " value ". " msg))
+        :validate (str "Invalid value for " option-name ": " value ". " msg)
+        (or msg (str error))))
+    (str error)))
+
 (defn ^:private error-msg [errors]
   (str "The following errors occurred while parsing your command:\n\n"
-       (string/join \newline errors)))
+       (string/join \newline (map cli-error-msg errors))))
 
 (def log-levels #{"error" "warn" "info" "debug"})
 
@@ -59,50 +77,83 @@
                         :default nil}
           :verbose {:desc "Enable verbose JSON-RPC protocol tracing"}}})
 
-(defn ^:private parse-opts
+(defn ^:private parse-server-opts
   [args]
-  (let [errors (atom [])
-        {:keys [args opts]} (cli/parse-args args (assoc cli-spec
-                                                        :error-fn (fn [error] (swap! errors conj error))))]
-    {:options (-> opts
-                  (assoc :dry? (:dry opts))
-                  (dissoc :dry)
-                  (assoc :raw? (:raw opts))
-                  (dissoc :raw))
-     :arguments args
-     :errors (when (seq @errors)
-               @errors)
-     :summary (cli/format-opts cli-spec)}))
+  (try
+    (let [{:keys [args opts]} (cli/parse-args args cli-spec)]
+      {:options opts
+       :arguments args})
+    (catch clojure.lang.ExceptionInfo e
+      {:options {} :errors [(ex-data e)]})))
+
+(defn ^:private read-chat-option-errors
+  [opts]
+  (cond-> []
+    (and (:db-cache-path opts) (seq (:workspace opts)))
+    (conj "Use either --db-cache-path or --workspace, not both")
+
+    (and (not (:db-cache-path opts)) (not (seq (:workspace opts))))
+    (conj "Missing required input source: pass --db-cache-path <PATH> or one or more --workspace <PATH>")
+
+    (and (:role opts) (not (:chat-id opts)))
+    (conj "--role requires --chat-id because role filtering applies to messages only")))
+
+(defn ^:private parse-read-chat-opts
+  [args]
+  (try
+    (let [valid-options (-> read-chat/read-chat-spec :spec keys set)
+          {:keys [args opts]} (cli/parse-args args (assoc read-chat/read-chat-spec
+                                                          :restrict valid-options))]
+      (if (:help opts)
+        {:options opts}
+        (let [option-errors (read-chat-option-errors opts)
+              positional-errors (when (seq args)
+                                  [(str "Unexpected argument(s): " (string/join " " args)
+                                        ". read-chat accepts options only; use --db-cache-path <PATH> or --workspace <PATH>, plus optional filters like --chat-id <ID>.")])]
+          {:options opts
+           :errors (seq (concat positional-errors option-errors))})))
+    (catch clojure.lang.ExceptionInfo e
+      {:options {} :errors [(ex-data e)]})))
 
 (defn ^:private parse [args]
-  (let [{:keys [options arguments errors summary]} (parse-opts args)]
-    (cond
-      (:help options)
-      {:exit-message (help summary) :ok? true}
-
-      (:version options)
-      {:exit-message (version) :ok? true}
-
-      errors
-      {:exit-message (error-msg errors)}
-
-      (and (= 1 (count arguments))
-           (#{"server"} (first arguments)))
-      {:action (first arguments) :options options}
-
-      :else
-      {:exit-message (help summary)})))
+  (if (= "read-chat" (first args))
+    (let [{:keys [options errors]} (parse-read-chat-opts (rest args))
+          help-text (read-chat/help)]
+      (cond
+        (:help options) {:exit-message help-text :ok? true}
+        errors          {:exit-message (error-msg errors)}
+        :else           {:action "read-chat" :options options}))
+    (let [{:keys [options arguments errors]} (parse-server-opts args)
+          help-text (help (cli/format-opts cli-spec))]
+      (cond
+        (:help options)    {:exit-message help-text :ok? true}
+        (:version options) {:exit-message (version) :ok? true}
+        errors             {:exit-message (error-msg errors)}
+        (and (= 1 (count arguments))
+             (= "server" (first arguments)))
+        {:action "server" :options options}
+        :else              {:exit-message help-text}))))
 
 (defn ^:private handle-action!
   [action options]
-  (when (= "server" action)
-    (when-some [cfg-file (:config-file options)]
-      (reset! config/custom-config-file-path* cfg-file))
-    (logger/set-level! (keyword (:log-level options)))
-    (network/setup! (config/read-file-configs))
-    (client/hato-client-global-setup! {})
-    (let [finished @(server/run-io-server! (:verbose options))]
-      {:result-code (if (= :done finished) 0 1)})))
+  (case action
+    "server"
+    (do
+      (when-some [cfg-file (:config-file options)]
+        (reset! config/custom-config-file-path* cfg-file))
+      (logger/set-level! (keyword (:log-level options)))
+      (network/setup! (config/read-file-configs))
+      (client/hato-client-global-setup! {})
+      (let [finished @(server/run-io-server! (:verbose options))]
+        {:result-code (if (= :done finished) 0 1)}))
+
+    "read-chat"
+    (try
+      (read-chat/run options)
+      (catch clojure.lang.ExceptionInfo e
+        (binding [*out* *err*]
+          (println (.getMessage e)))
+        {:result-code 1}))))
 
 (defn run!
   "Entrypoint for ECA CLI."

--- a/src/eca/message_sanitize.clj
+++ b/src/eca/message_sanitize.clj
@@ -1,0 +1,14 @@
+(ns eca.message-sanitize)
+
+(set! *warn-on-reflection* true)
+
+(defn strip-internal-message-fields
+  "Removes internal ECA metadata keys (:created-at, :content-id) from a message map."
+  [message]
+  (apply dissoc message [:created-at :content-id]))
+
+(defn sanitize-outbound-messages
+  "Strips internal ECA top-level message metadata from an outbound message
+   collection before provider serialization."
+  [messages]
+  (mapv strip-internal-message-fields messages))

--- a/src/eca/read_chat.clj
+++ b/src/eca/read_chat.clj
@@ -1,0 +1,190 @@
+(ns eca.read-chat
+  (:require
+   [clojure.java.io :as io]
+
+   [babashka.cli :as cli]
+   [cheshire.core :as cheshire]
+
+   [eca.cache :as cache]
+   [eca.db :as db]
+   [eca.shared :as shared])
+  (:import
+   [java.time Instant LocalDate ZoneOffset]))
+
+(set! *warn-on-reflection* true)
+
+(def read-chat-spec
+  {:order [:db-cache-path :workspace :chat-id :role :since :until :help]
+   :spec
+   {:help {:alias :h
+           :desc "Print read-chat options"}
+    :db-cache-path {:ref "<PATH>"
+                    :desc "Path to db.transit.json file"
+                    :coerce :string}
+    :workspace {:ref "<PATH>"
+                :desc "Workspace path. Repeat in the same order as the ECA session. Alternative to --db-cache-path"
+                :coerce []}
+    :chat-id {:ref "<CHAT-ID>"
+              :desc "Focus on a specific chat. Without it, lists all chats."
+              :coerce :string}
+    :role {:ref "<ROLE>"
+           :desc "Filter messages by exact persisted role string (detail mode only). Common roles: user, assistant, tool_call, tool_call_output, reason, server_tool_use, server_tool_result, image_generation_call, compact_marker, flag"
+           :coerce :string}
+    :since {:ref "<DATE>"
+            :desc "Listing: chats updated after date. Detail: messages created after date. Relative: 2h, 30m, 1d."
+            :coerce :string}
+    :until {:ref "<DATE>"
+            :desc "Listing: chats updated before date. Detail: messages created before date. Relative: 2h, 30m, 1d."
+            :coerce :string}}})
+
+(defn help
+  []
+  (str "Usage: eca read-chat [<options>]\n\n"
+       "Reads ECA's chat database cache and emits raw structured records as JSONL (one JSON object per line).\n\n"
+       "Listing mode (no --chat-id):\n"
+       "  Streams chat summaries, sorted by :updated-at desc.\n"
+       "  --since/--until filter chats by :updated-at.\n\n"
+       "Detail mode (--chat-id <id>):\n"
+       "  Streams messages from the chat in chronological order.\n"
+       "  --since/--until filter messages by :created-at.\n"
+       "  --role filters by message role.\n\n"
+       "Input source: pass either --db-cache-path <PATH> or one or more --workspace <PATH> values.\n"
+       "Workspace inputs are normalized and resolved with the same order-sensitive cache path logic ECA uses.\n\n"
+       "Date formats: relative (2h, 30m, 1d) or ISO-8601 (2025-01-01, 2025-01-01T00:00:00Z).\n\n"
+       "Options:\n"
+       (cli/format-opts read-chat-spec)))
+
+(defn read-db
+  [path]
+  (or (try
+        (db/read-transit-file (io/file path))
+        (catch Exception e
+          (throw (ex-info (str "Could not read or parse transit data in " path ": " (.getMessage e)
+                               ". The ECA server may be writing to this file.")
+                          {:path path :type ::read-error} e))))
+      (throw (ex-info (str "DB cache file is missing or empty: " path)
+                      {:path path :type ::file-not-found}))))
+
+(def ^:private relative-unit->ms
+  {"m" 60000
+   "h" 3600000
+   "d" 86400000})
+
+(defn- try-parse [f]
+  (try
+    (f)
+    (catch Exception _ nil)))
+
+(defn resolve-db-cache-path
+  "Resolve the db cache path from explicit opts.
+   Accepts either :db-cache-path or repeated :workspace paths."
+  [opts]
+  (if-let [path (:db-cache-path opts)]
+    path
+    (when-let [workspaces (seq (:workspace opts))]
+      (let [workspace-uris (mapv (fn [wpath] {:uri (shared/filename->uri wpath)}) workspaces)]
+        (str (cache/workspace-cache-file workspace-uris "db.transit.json" shared/uri->filename))))))
+
+(defn- parse-date-ms [^String s]
+  (or (when-let [[_ amount-str unit] (re-matches #"^(\d+)([mhd])$" s)]
+        (try-parse #(- (System/currentTimeMillis)
+                       (* (Long/parseLong amount-str) (get relative-unit->ms unit)))))
+      (try-parse #(.toEpochMilli ^Instant (Instant/parse s)))
+      (try-parse #(.toEpochMilli (.toInstant (.atStartOfDay ^LocalDate (LocalDate/parse s) ZoneOffset/UTC))))
+      (throw (ex-info (str "Invalid date format: " s
+                           ". Use relative (e.g. 2h, 30m, 1d) or ISO-8601 (e.g. 2025-01-01 or 2025-01-01T00:00:00Z).")
+                      {:value s :type ::invalid-date}))))
+
+(defn- parse-time-bounds
+  "Parse :since/:until from opts into epoch-millis. Returns {:since-ms ... :until-ms ...}."
+  [opts]
+  {:since-ms (when-let [value (:since opts)] (parse-date-ms value))
+   :until-ms (when-let [value (:until opts)] (parse-date-ms value))})
+
+(defn- within-time-bounds?
+  [timestamp {:keys [since-ms until-ms]}]
+  (and (or (nil? since-ms) (>= timestamp since-ms))
+       (or (nil? until-ms) (< timestamp until-ms))))
+
+(defn list-chats
+  "Returns a seq of chat summary maps, sorted by :updated-at desc."
+  [db opts]
+  (let [bounds (parse-time-bounds opts)]
+    (->> (:chats db)
+         (filter (fn [[_ chat]]
+                   (within-time-bounds? (or (:updated-at chat) 0) bounds)))
+         (sort-by (fn [[_ chat]] (or (:updated-at chat) 0)) >)
+         (map (fn [[chat-id chat]]
+                (assoc (select-keys chat [:title :status :model :created-at :updated-at :user-prompt-count])
+                       :id chat-id))))))
+
+(defn- message-matches?
+  [bounds role message]
+  (and (or (nil? role) (= role (:role message)))
+       (if (or (:since-ms bounds) (:until-ms bounds))
+         (when-let [created-at (:created-at message)]
+           (within-time-bounds? created-at bounds))
+         true)))
+
+(defn chat-messages
+  "Returns a map {:messages <lazy-seq> :warnings <vector>} for the given chat-id.
+   Throws ex-info if chat-id is not found in the db.
+
+   :messages is filtered per opts (since, until, role) and otherwise preserves
+   persisted message shape.
+   :warnings contains informational strings about silent exclusions (e.g. messages
+   without :created-at that were dropped by the time filter)."
+  [db chat-id opts]
+  (if-let [chat (get-in db [:chats chat-id])]
+    (let [messages (:messages chat [])
+          bounds (parse-time-bounds opts)
+          time-filter? (or (:since-ms bounds) (:until-ms bounds))
+          excluded-no-ts (when time-filter?
+                           (count (remove :created-at messages)))]
+      {:messages (filter #(message-matches? bounds (:role opts) %) messages)
+       :warnings (cond-> []
+                   (and time-filter? (pos? excluded-no-ts))
+                   (conj (str excluded-no-ts " message(s) without :created-at were excluded by time filter")))})
+    (throw (ex-info (str "Chat not found: " chat-id)
+                    {:chat-id chat-id :type ::chat-not-found}))))
+
+(defn emit-jsonl!
+  "Emit a seq of records as JSONL to *out*. One JSON object per line."
+  [records]
+  (doseq [r records]
+    (println (cheshire/generate-string r))))
+
+(defn- warn! [msg]
+  (binding [*out* *err*]
+    (println (str "Warning: " msg))))
+
+(defn run
+  [opts]
+  (let [path (resolve-db-cache-path opts)
+        workspace-inputs (seq (:workspace opts))]
+    (when-not path
+      (throw (ex-info "Missing required input source: pass --db-cache-path <PATH> or one or more --workspace <PATH>"
+                      {:type ::missing-path})))
+    (let [db (try
+               (read-db path)
+               (catch clojure.lang.ExceptionInfo e
+                 (if (= (:type (ex-data e)) ::file-not-found)
+                   (throw (ex-info
+                           (if workspace-inputs
+                             (str "Resolved DB cache path does not exist: " path
+                                  ". The provided --workspace set likely does not match the original ECA session workspaces.")
+                             (str "DB cache file not found: " path
+                                  ". Check --db-cache-path and try again."))
+                           (shared/assoc-some (ex-data e) :workspace-inputs workspace-inputs)
+                           e))
+                   (throw e))))]
+      (when-not (= (:version db) db/version)
+        (warn! (str "DB version mismatch. File has version " (:version db)
+                    ", expected " db/version ". Output may be incomplete.")))
+      (if-let [chat-id (:chat-id opts)]
+        (let [{:keys [messages warnings]} (chat-messages db chat-id opts)]
+          (doseq [w warnings] (warn! w))
+          (emit-jsonl! messages))
+        (emit-jsonl! (list-chats db opts)))
+      (.flush ^java.io.Writer *out*)
+      {:result-code 0})))

--- a/src/eca/shared.clj
+++ b/src/eca/shared.clj
@@ -428,15 +428,18 @@
   ;; Append compact marker tombstone + summary to preserve full history
   (swap! db* (fn [db]
                (let [summary (get-in db [:chats chat-id :last-summary])
-                     messages (get-in db [:chats chat-id :messages] [])]
+                     messages (get-in db [:chats chat-id :messages] [])
+                     now (System/currentTimeMillis)]
                  (assoc-in db [:chats chat-id :messages]
                            (conj messages
                                  {:role "compact_marker"
-                                  :content {:auto? (boolean auto-compact?)}}
+                                  :content {:auto? (boolean auto-compact?)}
+                                  :created-at now}
                                  {:role "user"
                                   :content [{:type :text
                                              :text (str "The conversation was compacted/summarized, consider this summary:\n"
-                                                        summary)}]})))))
+                                                        summary)}]
+                                  :created-at now})))))
 
   ;; Zero chat usage and clear transient per-chat rule validations.
   (swap! db* update-in [:chats chat-id] dissoc :usage :validated-path-rules)

--- a/test/eca/llm_api_test.clj
+++ b/test/eca/llm_api_test.clj
@@ -82,12 +82,30 @@
       (is (zero? dropped-count))
       (is (= past messages))))
 
+  (testing "internal-only top-level message fields are stripped before provider serialization"
+    (let [past [{:role "user"
+                 :content [{:type :text :text "hi"}]
+                 :created-at 123
+                 :content-id "c1"}
+                {:role "assistant"
+                 :content [{:type :text :text "ok"}]
+                 :created-at 456
+                 :content-id "c2"}]
+          {:keys [messages dropped-count]}
+          (llm-api/sanitize-past-messages-for-api :openai-chat past)]
+      (is (zero? dropped-count))
+      (is (= [{:role "user" :content [{:type :text :text "hi"}]}
+              {:role "assistant" :content [{:type :text :text "ok"}]}]
+             messages))
+      (is (every? #(not (contains? % :created-at)) messages))
+      (is (every? #(not (contains? % :content-id)) messages))))
+
   (testing "mixed history: tagged foreign entries dropped, untagged + matching kept"
     (let [past [{:role "user" :content [{:type :text :text "u1"}]}
                 {:role "reason" :content {:id "r0" :text "legacy"}}                            ; untagged → kept
                 {:role "reason" :content {:id "r1" :text "t" :api :anthropic}}                 ; foreign → dropped
                 {:role "reason" :content {:id "r2" :text "t" :api :openai-chat}}               ; matching → kept
-                {:role "assistant" :content [{:type :text :text "a"}]}]
+                {:role "assistant" :content [{:type :text :text "a"}] :created-at 999}]
           {:keys [messages dropped-count dropped-apis]}
           (llm-api/sanitize-past-messages-for-api :openai-chat past)]
       (is (= 1 dropped-count))
@@ -95,7 +113,8 @@
       (is (= 4 (count messages)))
       (is (= ["user" "reason" "reason" "assistant"] (mapv :role messages)))
       (is (= ["r0" "r2"]
-             (->> messages (filter #(= "reason" (:role %))) (map #(get-in % [:content :id]))))))))
+             (->> messages (filter #(= "reason" (:role %))) (map #(get-in % [:content :id])))))
+      (is (not (contains? (last messages) :created-at))))))
 
 (deftest default-model-test
   (testing "Custom provider defaultModel present"
@@ -268,6 +287,86 @@
           :sync? false}))
       (is (= true (:image-generation @captured*))
           "openai handler should receive :image-generation true")))
+
+  (testing "openai branch strips internal top-level message fields before reaching handler"
+    (let [captured* (atom nil)]
+      (with-redefs [llm-providers.openai/create-response!
+                    (fn [opts _callbacks] (reset! captured* opts) :ok)]
+        (#'eca.llm-api/prompt!
+         {:provider "openai"
+          :model "gpt-5.2"
+          :model-capabilities {:tools true
+                               :reason? false
+                               :web-search false
+                               :image-generation? false
+                               :model-name "gpt-5.2"}
+          :user-messages [{:role "user"
+                           :content [{:type :text :text "hi"}]
+                           :created-at 111
+                           :content-id "user-1"}]
+          :past-messages [{:role "assistant"
+                           :content [{:type :text :text "ok"}]
+                           :created-at 222
+                           :content-id "past-1"}]
+          :tools []
+          :provider-auth {:api-key "test-key"}
+          :config {:providers {"openai" {:url "https://api.openai.com" :key "test-key"}}}
+          :sync? false}))
+      (is (= [{:role "user" :content [{:type :text :text "hi"}]}]
+             (:user-messages @captured*)))
+      (is (= [{:role "assistant" :content [{:type :text :text "ok"}]}]
+             (:past-messages @captured*)))))
+
+  (testing "openai tool-call replay strips internal top-level message fields before follow-up request"
+    (let [seen-bodies* (atom [])]
+      (with-redefs [eca.llm-providers.openai/normalize-messages
+                    (fn [messages _supports-image?] (vec messages))
+                    eca.llm-providers.openai/base-responses-request!
+                    (fn [{:keys [body on-stream]}]
+                      (swap! seen-bodies* conj body)
+                      (if (= 1 (count @seen-bodies*))
+                        (on-stream "response.completed"
+                                   {:response {:status "completed"
+                                               :usage {:input_tokens 1 :output_tokens 1}
+                                               :output [{:type "function_call"
+                                                         :id "item_1"
+                                                         :call_id "call_1"
+                                                         :name "demo/tool"
+                                                         :arguments "{}"}]}})
+                        (on-stream "response.completed"
+                                   {:response {:status "completed"
+                                               :usage {:input_tokens 1 :output_tokens 1}
+                                               :output []}}))
+                      :ok)]
+        (llm-providers.openai/create-response!
+         {:model "gpt-5.2"
+          :instructions nil
+          :reason? false
+          :supports-image? false
+          :api-key "test-key"
+          :api-url "https://api.openai.com"
+          :past-messages []
+          :user-messages [{:role "user" :content [{:type :text :text "hi"}]}]
+          :tools [{:full-name "demo/tool" :description "d" :parameters {}}]
+          :web-search false
+          :image-generation false}
+         {:on-message-received identity
+          :on-error identity
+          :on-prepare-tool-call identity
+          :on-reason identity
+          :on-usage-updated identity
+          :on-server-web-search identity
+          :on-server-image-generation identity
+          :on-tools-called (fn [_]
+                             {:new-messages [{:role "assistant"
+                                              :content [{:type :text :text "after tool"}]
+                                              :created-at 333
+                                              :content-id "replay-1"}]
+                              :tools []})}))
+      (is (= 2 (count @seen-bodies*)))
+      (is (= [{:role "assistant"
+               :content [{:type :text :text "after tool"}]}]
+             (:input (second @seen-bodies*))))))
 
   (testing "openai branch forwards :image-generation false (or nil) when capability is off"
     (let [captured* (atom nil)]

--- a/test/eca/main_test.clj
+++ b/test/eca/main_test.clj
@@ -8,8 +8,8 @@
 
 (use-fixtures :once #(binding [matcher-combinators.config/*use-abbreviation* true] (%)))
 
-(deftest parse-opts-test
-  (are [args expected] (match? expected (#'main/parse-opts args))
+(deftest parse-server-opts-test
+  (are [args expected] (match? expected (#'main/parse-server-opts args))
     ;; help
     [] {:options {:help m/absent}}
     ["--help"] {:options {:help true}}
@@ -24,25 +24,41 @@
     ["-v"] {:options {:verbose m/absent}}
     ;; config-file
     [] {:options {:config-file m/absent}}
-    ["--config-file"] {:options {:config-file m/absent}}
     ["--config-file" "/dev/config.json"] {:options {:config-file "/dev/config.json"}}
+    ;; positional args are handled by parse
+    ["extra"] {:arguments ["extra"]}
     #_()))
 
 (deftest parse
   (testing "commands"
     (is (= nil (:action (#'main/parse []))))
-    (is (= "server" (:action (#'main/parse ["server"])))))
+    (is (= "server" (:action (#'main/parse ["server"]))))
+    (is (= "read-chat" (:action (#'main/parse ["read-chat" "--workspace" "/tmp/a"])))))
   (testing "final options"
     (is (string? (:exit-message (#'main/parse ["--help"]))))
     (is (string? (:exit-message (#'main/parse ["-h"]))))
     (is (string? (:exit-message (#'main/parse ["--version"])))))
-  (testing "options + commands"
+  (testing "legacy options + server command"
     (is (match?
          {:action "server"
           :options {:log-level "debug"}}
          (#'main/parse ["--log-level" "debug" "server"]))))
-  (testing "commands + options"
+  (testing "server command + options"
     (is (match?
          {:action "server"
           :options {:log-level "debug"}}
-         (#'main/parse ["server" "--log-level" "debug"])))))
+         (#'main/parse ["server" "--log-level" "debug"]))))
+  (testing "option values that match commands are not treated as commands"
+    (is (nil? (:action (#'main/parse ["--config-file" "server"]))))))
+
+(deftest parse-read-chat-command-position-test
+  (testing "read-chat supports options after the command"
+    (is (match?
+         {:action "read-chat"
+          :options {:workspace ["/tmp/a"]
+                    :chat-id "chat-1"}}
+         (#'main/parse ["read-chat" "--workspace" "/tmp/a" "--chat-id" "chat-1"]))))
+  (testing "read-chat requires command-first invocation"
+    (is (nil? (:action (#'main/parse ["--workspace" "/tmp/a" "read-chat" "--chat-id" "chat-1"])))))
+  (testing "server keeps previous single positional command behavior"
+    (is (string? (:exit-message (#'main/parse ["server" "extra"]))))))

--- a/test/eca/read_chat_test.clj
+++ b/test/eca/read_chat_test.clj
@@ -1,0 +1,468 @@
+(ns eca.read-chat-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [clojure.test :refer [are deftest is testing]]
+
+   [babashka.fs :as fs]
+   [cheshire.core :as cheshire]
+   [cognitect.transit :as transit]
+
+   [eca.cache :as cache]
+   [eca.db :as db]
+   [eca.main :as main]
+   [eca.read-chat :as read-chat]
+   [eca.shared :as shared]))
+
+(set! *warn-on-reflection* true)
+
+(defn- instant->ms [^String s]
+  (.toEpochMilli (java.time.Instant/parse s)))
+
+(def jan-1-ms (instant->ms "2024-01-01T00:00:00Z"))
+(def jan-2-ms (instant->ms "2024-01-02T00:00:00Z"))
+(def feb-1-ms (instant->ms "2024-02-01T00:00:00Z"))
+(def feb-2-ms (instant->ms "2024-02-02T00:00:00Z"))
+
+(def sample-db
+  {:version db/version
+   :chats {"chat-1" {:id "chat-1"
+                     :title "Test Chat 1"
+                     :status :idle
+                     :model "anthropic/claude-sonnet-4-6"
+                     :created-at jan-1-ms
+                     :updated-at jan-2-ms
+                     :user-prompt-count 3
+                     :messages [{:role "user" :content "Hello" :content-id "m1" :created-at jan-1-ms}
+                                {:role "assistant" :content "Hi there" :content-id "m2" :created-at (inc jan-1-ms)}
+                                {:role "user" :content "How are you?" :content-id "m3" :created-at jan-2-ms}
+                                {:role "assistant" :content "I'm fine" :content-id "m4" :created-at (inc jan-2-ms)}
+                                {:role "tool_call" :content "some tool" :content-id "m5" :created-at (+ 2 jan-2-ms)}]}
+           "chat-2" {:id "chat-2"
+                     :title "Test Chat 2"
+                     :status :running
+                     :model "openai/gpt-5"
+                     :created-at feb-1-ms
+                     :updated-at feb-2-ms
+                     :user-prompt-count 1
+                     :messages [{:role "user" :content "Question" :content-id "m6" :created-at feb-1-ms}]}
+           "chat-3" {:id "chat-3"
+                     :title "Multimodal Chat"
+                     :status :idle
+                     :model "anthropic/claude-sonnet-4-6"
+                     :created-at jan-1-ms
+                     :updated-at jan-2-ms
+                     :user-prompt-count 2
+                     :messages [{:role "user"
+                                 :content [{:type :text :text "What is in this image?"}
+                                           {:type :image :base64 "iVBOR..." :media-type "image/png"}]
+                                 :content-id "m7"
+                                 :created-at jan-1-ms}
+                                {:role "assistant"
+                                 :content [{:type :text :text "That's a diagram."}]
+                                 :content-id "m8"
+                                 :created-at jan-2-ms}
+                                {:role "user"
+                                 :content [{:type :text :text "First line"}
+                                           {:type :text :text "Second line"}]
+                                 :content-id "m9"
+                                 :created-at (inc jan-2-ms)}
+                                {:role "tool_call"
+                                 :content {:name "Read" :arguments {:path "/foo/bar"} :id "tc-1"}
+                                 :content-id "m10"
+                                 :created-at (+ 2 jan-2-ms)}]}}})
+
+(defn- write-transit-file [path data]
+  (with-open [os (io/output-stream path)]
+    (transit/write (transit/writer os :json) data)))
+
+(defn- with-tmp-transit-file [data f]
+  (let [tmp (fs/create-temp-file {:prefix "eca-test" :suffix ".transit.json"})]
+    (try
+      (write-transit-file (str tmp) data)
+      (f (str tmp))
+      (finally
+        (fs/delete tmp)))))
+
+(defn- parse-jsonl [s]
+  (->> (string/split-lines s)
+       (remove string/blank?)
+       (mapv #(cheshire/parse-string % keyword))))
+
+(defn- workspace-db-path [paths]
+  (str (cache/workspace-cache-file
+        (mapv (fn [path] {:uri (shared/filename->uri path)}) paths)
+        "db.transit.json"
+        shared/uri->filename)))
+
+(defn- listing-ids [opts]
+  (set (map :id (read-chat/list-chats sample-db opts))))
+
+(defn- message-ids [chat-id opts]
+  (mapv :content-id (:messages (read-chat/chat-messages sample-db chat-id opts))))
+
+;; read-db tests
+
+(deftest read-db-valid-file-test
+  (testing "reads a valid transit file"
+    (with-tmp-transit-file sample-db
+      (fn [path]
+        (let [db (read-chat/read-db path)]
+          (is (= 6 (:version db)))
+          (is (= 3 (count (:chats db)))))))))
+
+(deftest read-db-missing-file-test
+  (testing "throws ex-info for missing file"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (read-chat/read-db "/nonexistent/path/db.transit.json")))))
+
+(deftest read-db-corrupted-file-test
+  (testing "throws ex-info for corrupted transit file"
+    (let [tmp (fs/create-temp-file {:prefix "eca-test" :suffix ".transit.json"})]
+      (try
+        (spit (str tmp) "this is not transit data!!!")
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (read-chat/read-db (str tmp))))
+        (finally
+          (fs/delete tmp))))))
+
+;; list-chats tests
+
+(deftest list-chats-no-filter-test
+  (testing "lists all chat summaries without message bodies"
+    (let [result (vec (read-chat/list-chats sample-db {}))]
+      (is (= #{"chat-1" "chat-2" "chat-3"} (set (map :id result))))
+      (is (every? #(every? % [:id :title :status :model :created-at :updated-at :user-prompt-count]) result))
+      (is (not-any? #(contains? % :messages) result)))))
+
+(deftest list-chats-uses-db-key-as-id-test
+  (testing "listing emits the DB key as the id that --chat-id can use"
+    (let [db {:chats {"db-key" {:id "stale-stored-id"
+                                :title "Mismatched id chat"
+                                :status :idle
+                                :model "test/model"
+                                :created-at jan-1-ms
+                                :updated-at jan-2-ms
+                                :user-prompt-count 1
+                                :messages []}}}
+          result (vec (read-chat/list-chats db {}))]
+      (is (= "db-key" (:id (first result)))))))
+
+(deftest chat-messages-uses-db-key-as-chat-id-test
+  (testing "detail mode uses the same DB key emitted by listing mode"
+    (let [db {:chats {"db-key" {:id "stale-stored-id"
+                                :messages [{:role "user"
+                                            :content "Hello"
+                                            :content-id "m1"
+                                            :created-at jan-1-ms}]}}}
+          {:keys [messages]} (read-chat/chat-messages db "db-key" {})]
+      (is (= ["Hello"] (mapv :content messages)))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (read-chat/chat-messages db "stale-stored-id" {}))))))
+
+(deftest list-chats-sorted-by-updated-at-desc-test
+  (testing "chats are sorted by :updated-at descending"
+    (let [result (vec (read-chat/list-chats sample-db {}))
+          updated-ats (mapv :updated-at result)]
+      (is (= updated-ats (vec (reverse (sort updated-ats)))))
+      ;; chat-2 has feb-2 which is newest, so it must be first
+      (is (= "chat-2" (:id (first result)))))))
+
+(deftest list-chats-sorted-nil-updated-at-test
+  (testing "chats with nil :updated-at end up last"
+    (let [db {:chats {"a" {:id "a" :updated-at 100}
+                      "b" {:id "b"}
+                      "c" {:id "c" :updated-at 200}}}
+          result (vec (read-chat/list-chats db {}))]
+      (is (= ["c" "a" "b"] (mapv :id result))))))
+
+(deftest list-chats-time-filter-test
+  (testing "filters chats by updated-at time bounds"
+    (are [opts expected-ids] (= expected-ids (listing-ids opts))
+      {:since "2024-01-15"} #{"chat-2"}
+      {:until "2024-01-15"} #{"chat-1" "chat-3"}
+      {:since "2024-01-01" :until "2024-02-28"} #{"chat-1" "chat-2" "chat-3"}
+      {:since "2024-01-02T00:00:00Z"} #{"chat-1" "chat-2" "chat-3"})))
+
+(deftest list-chats-empty-test
+  (testing "returns empty seq for empty chats"
+    (let [result (vec (read-chat/list-chats {:chats {}} {}))]
+      (is (= [] result)))))
+
+(deftest list-chats-invalid-date-test
+  (testing "throws ex-info for invalid date format"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (doall (read-chat/list-chats sample-db {:since "not-a-date"}))))))
+
+;; relative time parsing tests
+
+(deftest list-chats-since-relative-test
+  (testing "filters chats with relative --since"
+    (let [now-ms (System/currentTimeMillis)
+          db (assoc sample-db :chats
+                    {"old" {:id "old" :title "Old" :status :idle :model "x"
+                            :created-at (- now-ms 43200000) :updated-at (- now-ms 43200000) :user-prompt-count 0}
+                     "recent" {:id "recent" :title "Recent" :status :idle :model "x"
+                               :created-at (- now-ms 1800000) :updated-at (- now-ms 1800000) :user-prompt-count 0}})]
+      (testing "1h includes recent chat only"
+        (let [result (vec (read-chat/list-chats db {:since "1h"}))]
+          (is (some #(= "recent" (:id %)) result))
+          (is (not (some #(= "old" (:id %)) result)))))
+      (testing "1d includes both chats"
+        (let [result (vec (read-chat/list-chats db {:since "1d"}))]
+          (is (= 2 (count result))))))))
+
+(deftest parse-date-relative-formats-test
+  (testing "relative formats"
+    (are [input delta-ms] (let [parsed-ms (#'read-chat/parse-date-ms input)
+                              expected-ms (- (System/currentTimeMillis) delta-ms)]
+                          (<= (Math/abs (long (- parsed-ms expected-ms))) 1000))
+      "30m" (* 30 60000)
+      "2h" (* 2 3600000)
+      "1d" 86400000))
+  (testing "invalid relative format throws"
+    (is (thrown? clojure.lang.ExceptionInfo (#'read-chat/parse-date-ms "2w"))))
+  (testing "absolute still works"
+    (are [input] (integer? (#'read-chat/parse-date-ms input))
+      "2024-01-01"
+      "2024-01-01T00:00:00Z")))
+
+;; chat-messages tests
+
+(deftest chat-messages-no-options-test
+  (testing "returns all messages for given chat-id"
+    (let [{:keys [messages warnings]} (read-chat/chat-messages sample-db "chat-1" {})]
+      (is (= 5 (count (vec messages))))
+      (is (= [] warnings)))))
+
+(deftest chat-messages-missing-chat-test
+  (testing "throws ex-info for missing chat-id"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (read-chat/chat-messages sample-db "nonexistent" {})))))
+
+(deftest chat-messages-filter-test
+  (testing "filters messages by role and time bounds"
+    (are [opts expected-message-ids] (= expected-message-ids (message-ids "chat-1" opts))
+      {:role "user"} ["m1" "m3"]
+      {:since "2024-01-02"} ["m3" "m4" "m5"]
+      {:until "2024-01-02"} ["m1" "m2"]
+      {:since "2024-01-01T00:00:01Z" :until "2024-01-03"} ["m3" "m4" "m5"]
+      {:since "2024-01-02" :role "user"} ["m3"])))
+
+(deftest chat-messages-since-excludes-messages-without-created-at-test
+  (testing "messages without :created-at are excluded when --since is set; a warning is reported"
+    (let [db-without-ts (update-in sample-db [:chats "chat-1" :messages]
+                                   (fn [msgs] (mapv #(dissoc % :created-at) msgs)))
+          {:keys [messages warnings]} (read-chat/chat-messages db-without-ts "chat-1" {:since "2025-01-01"})]
+      (is (= 0 (count (vec messages))))
+      (is (= 1 (count warnings)))
+      (is (string/includes? (first warnings) "5"))
+      (is (string/includes? (first warnings) "without :created-at")))))
+
+(deftest chat-messages-no-warning-without-time-filter-test
+  (testing "no warning is produced when no time filter is active"
+    (let [db-without-ts (update-in sample-db [:chats "chat-1" :messages]
+                                   (fn [msgs] (mapv #(dissoc % :created-at) msgs)))
+          {:keys [warnings]} (read-chat/chat-messages db-without-ts "chat-1" {})]
+      (is (= [] warnings)))))
+
+;; raw content preservation tests
+
+(deftest chat-messages-preserves-vector-content-test
+  (testing "message content vectors are preserved as stored"
+    (let [{:keys [messages]} (read-chat/chat-messages sample-db "chat-3" {})
+          msgs (vec messages)]
+      (is (= [{:type :text :text "What is in this image?"}
+              {:type :image :base64 "iVBOR..." :media-type "image/png"}]
+             (:content (first msgs))))
+      (is (= [{:type :text :text "First line"}
+              {:type :text :text "Second line"}]
+             (:content (nth msgs 2)))))))
+
+(deftest chat-messages-preserves-tool-map-content-test
+  (testing "structured tool content maps are preserved as stored"
+    (let [{:keys [messages]} (read-chat/chat-messages sample-db "chat-3" {})
+          tool-msg (last (vec messages))]
+      (is (= "tool_call" (:role tool-msg)))
+      (is (= {:name "Read" :arguments {:path "/foo/bar"} :id "tc-1"}
+             (:content tool-msg))))))
+
+;; emit-jsonl! tests
+
+(deftest emit-jsonl-one-line-per-record-test
+  (testing "emits one valid JSON object per line"
+    (let [data [{:a 1} {:b 2} {:c "hello"}]
+          out (with-out-str (read-chat/emit-jsonl! data))
+          lines (string/split-lines (string/trim out))]
+      (is (= 3 (count lines)))
+      (is (= {:a 1} (cheshire/parse-string (nth lines 0) keyword)))
+      (is (= {:b 2} (cheshire/parse-string (nth lines 1) keyword)))
+      (is (= {:c "hello"} (cheshire/parse-string (nth lines 2) keyword))))))
+
+(deftest emit-jsonl-empty-test
+  (testing "empty seq emits nothing"
+    (is (= "" (with-out-str (read-chat/emit-jsonl! []))))))
+
+(deftest emit-jsonl-escapes-newlines-in-content-test
+  (testing "multi-line content stays on a single line via JSON escaping"
+    (let [data [{:content "line one\nline two"}]
+          out (with-out-str (read-chat/emit-jsonl! data))
+          lines (string/split-lines (string/trim out))]
+      (is (= 1 (count lines)))
+      (is (= "line one\nline two" (:content (cheshire/parse-string (first lines) keyword)))))))
+
+;; CLI integration tests
+
+(deftest parse-read-chat-command-test
+  (testing "parse recognizes read-chat command with explicit db path"
+    (let [result (#'main/parse ["read-chat" "--db-cache-path" "/tmp/db.transit.json"])]
+      (is (= "read-chat" (:action result)))
+      (is (= "/tmp/db.transit.json" (get-in result [:options :db-cache-path])))))
+  (testing "parse recognizes repeated workspace inputs"
+    (let [result (#'main/parse ["read-chat" "--workspace" "/tmp/a" "--workspace" "/tmp/b"])]
+      (is (= "read-chat" (:action result)))
+      (is (= ["/tmp/a" "/tmp/b"] (get-in result [:options :workspace]))))))
+
+(deftest parse-read-chat-help-test
+  (testing "parse returns help for read-chat --help"
+    (let [result (#'main/parse ["read-chat" "--help"])]
+      (is (:ok? result))
+      (is (string/includes? (:exit-message result) "read-chat"))
+      (is (string/includes? (:exit-message result) "raw structured records as JSONL")))))
+
+(deftest parse-read-chat-validation-test
+  (testing "missing input source is reported clearly"
+    (let [result (#'main/parse ["read-chat"])]
+      (is (nil? (:ok? result)))
+      (is (string/includes? (:exit-message result) "Missing required input source"))
+      (is (not (string/includes? (:exit-message result) ":org.babashka/cli")))))
+  (testing "db path and workspace are mutually exclusive"
+    (let [result (#'main/parse ["read-chat" "--db-cache-path" "/tmp/db.transit.json" "--workspace" "/tmp/a"])]
+      (is (nil? (:action result)))
+      (is (string/includes? (:exit-message result) "Use either --db-cache-path or --workspace, not both"))))
+  (testing "unexpected positional arguments are rejected"
+    (let [result (#'main/parse ["read-chat" "--db-cache-path" "/tmp/db.transit.json" "extra"])]
+      (is (nil? (:action result)))
+      (is (string/includes? (:exit-message result) "Unexpected argument(s): extra"))))
+  (testing "unknown options are rejected"
+    (let [result (#'main/parse ["read-chat" "--db-cache-path" "/tmp/db.transit.json" "--chatd-id" "abc"])]
+      (is (nil? (:action result)))
+      (is (string/includes? (:exit-message result) "Unknown option --chatd-id"))))
+  (testing "role filtering requires detail mode"
+    (let [result (#'main/parse ["read-chat" "--db-cache-path" "/tmp/db.transit.json" "--role" "nope"])]
+      (is (nil? (:action result)))
+      (is (string/includes? (:exit-message result) "--role requires --chat-id"))))
+  (testing "exact role strings remain allowed in detail mode"
+    (let [result (#'main/parse ["read-chat" "--db-cache-path" "/tmp/db.transit.json" "--chat-id" "chat-1" "--role" "future_role"])]
+      (is (= "read-chat" (:action result)))
+      (is (= "future_role" (get-in result [:options :role])))))
+  (testing "date options stay as parsed CLI values"
+    (let [result (#'main/parse ["read-chat" "--db-cache-path" "/tmp/db.transit.json" "--since" "2024-01-01"])]
+      (is (= "read-chat" (:action result)))
+      (is (= "2024-01-01" (get-in result [:options :since])))
+      (is (not (contains? (:options result) :since-ms))))))
+
+(deftest parse-top-level-help-still-works-test
+  (testing "top-level --help still works"
+    (let [result (#'main/parse ["--help"])]
+      (is (:ok? result))
+      (is (string/includes? (:exit-message result) "read-chat")))))
+
+;; run integration tests
+
+(deftest run-listing-emits-jsonl-test
+  (testing "run prints JSONL listing to stdout with explicit db path"
+    (with-tmp-transit-file sample-db
+      (fn [path]
+        (let [output (with-out-str
+                       (read-chat/run {:db-cache-path path}))
+              records (parse-jsonl output)]
+          (is (= 3 (count records)))
+          (is (every? #(contains? % :id) records))
+          ;; sorted desc by :updated-at, chat-2 has newest
+          (is (= "chat-2" (:id (first records))))))))
+  (testing "run resolves workspace cache path using ECA cache logic"
+    (let [workspaces [(str (fs/create-temp-dir {:prefix "eca-ws-a"}))
+                      (str (fs/create-temp-dir {:prefix "eca-ws-b"}))]
+          cache-root (fs/create-temp-dir {:prefix "eca-cache"})]
+      (try
+        (with-redefs [cache/global-dir (fn [] (io/file (str cache-root)))]
+          (let [path (workspace-db-path workspaces)]
+            (io/make-parents path)
+            (write-transit-file path sample-db)
+            (let [output (with-out-str
+                           (read-chat/run {:workspace workspaces}))
+                  records (parse-jsonl output)]
+              (is (= 3 (count records)))
+              (is (= "chat-2" (:id (first records)))))))
+        (finally
+          (doseq [ws workspaces]
+            (fs/delete-tree ws))
+          (fs/delete-tree cache-root))))))
+
+(deftest run-detail-emits-message-stream-test
+  (testing "run emits one message per line in detail mode"
+    (with-tmp-transit-file sample-db
+      (fn [path]
+        (let [output (with-out-str
+                       (read-chat/run {:db-cache-path path :chat-id "chat-1"}))
+              records (parse-jsonl output)]
+          (is (= 5 (count records)))
+          (is (every? #(contains? % :role) records))
+          (is (every? #(contains? % :content) records))
+          ;; chat metadata is NOT in detail output
+          (is (not-any? #(contains? % :title) records)))))))
+
+(deftest run-missing-path-test
+  (testing "run throws a clear error for missing explicit db file"
+    (let [^clojure.lang.ExceptionInfo e (try
+                                          (read-chat/run {:db-cache-path "/nonexistent/path"})
+                                          nil
+                                          (catch clojure.lang.ExceptionInfo e
+                                            e))]
+      (is e)
+      (is (string/includes? (.getMessage e) "DB cache file not found: /nonexistent/path"))
+      (is (string/includes? (.getMessage e) "Check --db-cache-path")))))
+
+(deftest run-missing-workspace-derived-path-test
+  (testing "run throws a clear error when the resolved workspace cache does not exist"
+    (let [workspaces ["/tmp/eca-missing-a" "/tmp/eca-missing-b"]
+          ^clojure.lang.ExceptionInfo e (try
+                                          (read-chat/run {:workspace workspaces})
+                                          nil
+                                          (catch clojure.lang.ExceptionInfo e
+                                            e))]
+      (is e)
+      (is (string/includes? (.getMessage e) "Resolved DB cache path does not exist"))
+      (is (string/includes? (.getMessage e) "--workspace set likely does not match")))))
+
+(deftest run-missing-chat-id-test
+  (testing "run throws for missing chat-id"
+    (with-tmp-transit-file sample-db
+      (fn [path]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (read-chat/run {:db-cache-path path :chat-id "nonexistent"})))))))
+
+(deftest run-invalid-date-test
+  (testing "run throws a clear error for invalid date filters"
+    (with-tmp-transit-file sample-db
+      (fn [path]
+        (let [^clojure.lang.ExceptionInfo e (try
+                                              (read-chat/run {:db-cache-path path :since "yesterday"})
+                                              nil
+                                              (catch clojure.lang.ExceptionInfo e
+                                                e))]
+          (is e)
+          (is (string/includes? (.getMessage e) "Invalid date format: yesterday")))))))
+
+(deftest run-warning-on-excluded-messages-test
+  (testing "run prints warning to stderr when messages are excluded by time filter"
+    (with-tmp-transit-file (update-in sample-db [:chats "chat-1" :messages]
+                                      (fn [msgs] (mapv #(dissoc % :created-at) msgs)))
+      (fn [path]
+        (let [err-buf (java.io.StringWriter.)
+              out (binding [*err* err-buf]
+                    (with-out-str
+                      (read-chat/run {:db-cache-path path :chat-id "chat-1" :since "2025-01-01"})))]
+          (is (= "" (string/trim out)))
+          (is (string/includes? (str err-buf) "without :created-at")))))))


### PR DESCRIPTION
New `eca read-chat` subcommand streams raw chat records from the DB cache as JSONL — listing chats or filtering messages by time, role, and chat-id — without requiring a running server.

To support read-chat's time filtering, every message now receives a :created-at timestamp at insertion (backfilled for compact markers and flags). The new eca.message-sanitize namespace centralizes stripping of internal metadata (:created-at, :content-id) from messages before they reach LLM providers, replacing per-provider (dissoc :content-id) calls with a single sanitize-outbound-messages entry point called from llm-api and each provider's tool-call loop.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
