### PR TITLE
Fix Anthropic Streaming Responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Anthropic: request uncompressed SSE (`accept-encoding: identity` + `:decompress-body false`) so streamed responses arrive token-by-token instead of all at once.
 - Remote REST API now surfaces tool calls awaiting approval: `GET /api/v1/chats/:id` returns `pendingToolCalls` and session/list-chats entries include `pendingApprovalCount`.
 
 ## 0.136.2

--- a/src/eca/llm_providers/anthropic.clj
+++ b/src/eca/llm_providers/anthropic.clj
@@ -97,7 +97,9 @@
                  (merge
                   (assoc-some
                    {"anthropic-version" "2023-06-01"
-                    "Content-Type" "application/json"}
+                    "Content-Type" "application/json"
+                    ;; Keep SSE uncompressed so it streams token-by-token (see :decompress-body below).
+                    "accept-encoding" "identity"}
                    "x-api-key" (when-not oauth? api-key)
                    "Authorization" (when oauth? (str "Bearer " api-key))
                    "anthropic-beta" (when oauth? "oauth-2025-04-20"))
@@ -115,6 +117,7 @@
                                    {:headers headers
                                     :body (json/generate-string body)
                                     :throw-exceptions? false
+                                    :decompress-body false
                                     :http-client (client/merge-with-global-http-client http-client)
                                     :as (if on-stream :stream :json)})]
         (if (not= 200 status)


### PR DESCRIPTION
## Problem

Anthropic streaming responses arrive all at once at the end instead of
token-by-token. Anthropic gzip-compresses the SSE body and `hato` decompresses
it, but `GZIPInputStream` only emits bytes once a full deflate block arrives,
so the stream is buffered until the response is nearly complete.

## Fix

Send `accept-encoding: identity` and set hato's
`:decompress-body false` so the event-stream stays uncompressed and can be read
line-by-line.

## Tradeoff
SSE text is no longer gzipped, but for interactive use it's negligible and time-to-first-token improves.
Server-side chunk granularity is unchanged.