### PR TITLE
Expose per-chat model/variant/agent in get-chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remote REST API: `GET /api/v1/chats/:id` now exposes the chat's effective `model`, `variant` and `agent` (per-chat override, falling back to the resolved session default).
+
 ## 0.136.4
 
 - Add `/debug-chat [filepath]` command dumping an obfuscated snapshot of the current chat (message structure + model/variant/tool/status metadata) to a file for debugging stuck chats.

--- a/src/eca/remote/handlers.clj
+++ b/src/eca/remote/handlers.clj
@@ -79,19 +79,36 @@
     :updated-at (:updated-at chat)
     :pending-approval-count (pending-approval-count chat)}))
 
+(defn ^:private resolve-default-model
+  "Session-level default model: explicit selection from last notified config,
+   falling back to the computed default."
+  [db config]
+  (or (get-in db [:last-config-notified :chat :select-model])
+      (f.chat/default-model db config)))
+
+(defn ^:private resolve-default-agent
+  "Session-level default agent: explicit selection from last notified config,
+   falling back to the validated configured default agent."
+  [db config]
+  (or (get-in db [:last-config-notified :chat :select-agent])
+      (config/validate-agent-name
+       (or (:defaultAgent (:chat config))
+           (:defaultAgent config))
+       config)))
+
+(defn ^:private resolve-default-variant
+  "Session-level selected variant, may be nil when none is selected."
+  [db]
+  (get-in db [:last-config-notified :chat :select-variant]))
+
 (defn ^:private session-state
   "Builds the session state map used for both GET /session and SSE session:connected."
   [db config]
   (let [last-config (:last-config-notified db)
-        default-model (or (get-in last-config [:chat :select-model])
-                          (f.chat/default-model db config))
-        default-agent-name (or (get-in last-config [:chat :select-agent])
-                               (config/validate-agent-name
-                                (or (:defaultAgent (:chat config))
-                                    (:defaultAgent config))
-                                config))
+        default-model (resolve-default-model db config)
+        default-agent-name (resolve-default-agent db config)
         variants (or (get-in last-config [:chat :variants]) [])
-        selected-variant (get-in last-config [:chat :select-variant])]
+        selected-variant (resolve-default-variant db)]
     {:version (config/eca-version)
      :protocolVersion "1.0"
      :workspaceFolders (mapv #(shared/uri->filename (:uri %)) (:workspace-folders db))
@@ -143,16 +160,23 @@
 
 (defn handle-get-chat [{:keys [db*]} _request chat-id]
   (if-let [chat (chat-or-404 db* chat-id)]
-    (json-response
-     (camel-keys
-      {:id (:id chat)
-       :title (:title chat)
-       :status (or (:status chat) :idle)
-       :created-at (:created-at chat)
-       :updated-at (:updated-at chat)
-       :messages (or (:messages chat) [])
-       :task (:task chat)
-       :pending-tool-calls (pending-tool-calls chat)}))
+    (let [db @db*
+          config (config/all db)]
+      (json-response
+       (camel-keys
+        {:id (:id chat)
+         :title (:title chat)
+         :status (or (:status chat) :idle)
+         :created-at (:created-at chat)
+         :updated-at (:updated-at chat)
+         :messages (or (:messages chat) [])
+         :task (:task chat)
+         :pending-tool-calls (pending-tool-calls chat)
+         ;; Effective selection: per-chat override if set, otherwise the
+         ;; resolved session-level default. :variant may legitimately be nil.
+         :model (or (:model chat) (resolve-default-model db config))
+         :variant (or (:variant chat) (resolve-default-variant db))
+         :agent (or (:agent chat) (resolve-default-agent db config))})))
     (error-response 404 "chat_not_found" (str "Chat " chat-id " does not exist"))))
 
 (defn handle-prompt [{:keys [db*] :as components} request chat-id]

--- a/test/eca/remote/handlers_test.clj
+++ b/test/eca/remote/handlers_test.clj
@@ -136,7 +136,42 @@
                          "tc-2" {:status :completed :name "y"}}})
     (let [response (handlers/handle-get-chat (components) nil "c1")
           body (json/parse-string (:body response) true)]
-      (is (= [] (:pendingToolCalls body))))))
+      (is (= [] (:pendingToolCalls body)))))
+
+  (testing "returns per-chat model/variant/agent overrides when set"
+    (swap! (h/db*) assoc-in [:chats "c1"]
+           {:id "c1" :title "T" :status :idle
+            :model "claude-custom" :variant "high" :agent "plan"})
+    (let [response (handlers/handle-get-chat (components) nil "c1")
+          body (json/parse-string (:body response) true)]
+      (is (= 200 (:status response)))
+      (is (= "claude-custom" (:model body)))
+      (is (= "high" (:variant body)))
+      (is (= "plan" (:agent body)))))
+
+  (testing "falls back to resolved session-level defaults when chat has no override"
+    (swap! (h/db*) assoc-in [:chats "c1"] {:id "c1" :title "T" :status :idle})
+    (let [response (handlers/handle-get-chat (components) nil "c1")
+          body (json/parse-string (:body response) true)
+          session (json/parse-string (:body (handlers/handle-session (components) nil)) true)]
+      (is (= 200 (:status response)))
+      (is (= (:selectModel session) (:model body)))
+      (is (= (:selectAgent session) (:agent body)))
+      (is (= (:selectedVariant session) (:variant body)))))
+
+  (testing "per-chat overrides take precedence over session-level defaults"
+    (swap! (h/db*) assoc
+           :last-config-notified {:chat {:select-model "session-model"
+                                         :select-agent "session-agent"
+                                         :select-variant "session-variant"}})
+    (swap! (h/db*) assoc-in [:chats "c1"]
+           {:id "c1" :title "T" :status :idle :model "chat-model" :agent "chat-agent"})
+    (let [response (handlers/handle-get-chat (components) nil "c1")
+          body (json/parse-string (:body response) true)]
+      (is (= "chat-model" (:model body)))
+      (is (= "chat-agent" (:agent body)))
+      ;; variant has no per-chat override, so it falls back to the session value
+      (is (= "session-variant" (:variant body))))))
 
 (deftest handle-stop-test
   (testing "returns 404 for missing chat"


### PR DESCRIPTION
GET /api/v1/chats/:id now returns the chat's effective model, variant and agent (per-chat override, falling back to the resolved session default). Resolution helpers are extracted from session-state and reused to avoid duplication.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
