### PR TITLE
Fix Anthropic 400 on empty thinking blocks in multi-turn chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remote REST API: `GET /api/v1/chats/:id` now exposes the chat's effective `model`, `variant` and `agent` (per-chat override, falling back to the resolved session default).
+- Anthropic: serialize empty thinking blocks as `""` instead of nil, fixing a 400 on multi-turn chats with extended thinking. (#481)
 
 ## 0.136.4
 

--- a/src/eca/llm_providers/anthropic.clj
+++ b/src/eca/llm_providers/anthropic.clj
@@ -239,7 +239,7 @@
                               :data (:data content)}
                              {:type "thinking"
                               :signature (:external-id content)
-                              :thinking (:text content)})]})
+                              :thinking (or (:text content) "")})]})
 
               "server_tool_use"
               (when-not foreign-api?

--- a/test/eca/llm_providers/anthropic_test.clj
+++ b/test/eca/llm_providers/anthropic_test.clj
@@ -240,6 +240,41 @@
                        {:type :text :text "Here are the results."}]}]
            result)))))
 
+(deftest reason-empty-thinking-test
+  (testing "reason message with nil :text serializes :thinking to \"\" (not nil)"
+    ;; Regression: Anthropic rejects requests where a replayed thinking block
+    ;; has a non-string :thinking field with
+    ;;   400 messages.N.content.0.thinking.thinking: Input should be a valid string
+    ;; This happens when a content_block_start of type "thinking" arrived with no
+    ;; thinking_delta before content_block_stop, leaving (:text content) nil.
+    (let [out (vec (#'llm-providers.anthropic/normalize-messages
+                    [{:role "reason" :content {:id "r1" :external-id "sig1" :text nil}}]
+                    true))
+          thinking-block (-> out first :content first)]
+      (is (= 1 (count out)))
+      (is (match? {:role "assistant"
+                   :content [{:type "thinking" :signature "sig1" :thinking ""}]}
+                  (first out)))
+      (is (= "" (:thinking thinking-block)))
+      (is (string? (:thinking thinking-block)))))
+  (testing "reason message with missing :text key also serializes :thinking to \"\""
+    (let [out (vec (#'llm-providers.anthropic/normalize-messages
+                    [{:role "reason" :content {:id "r1" :external-id "sig1"}}]
+                    true))]
+      (is (= "" (-> out first :content first :thinking)))))
+  (testing "reason message with present :text is preserved verbatim"
+    (let [out (vec (#'llm-providers.anthropic/normalize-messages
+                    [{:role "reason" :content {:id "r1" :external-id "sig1" :text "Let me think."}}]
+                    true))]
+      (is (= "Let me think." (-> out first :content first :thinking)))))
+  (testing "redacted reason message is unaffected (no :thinking field)"
+    (let [out (vec (#'llm-providers.anthropic/normalize-messages
+                    [{:role "reason" :content {:id "r1" :redacted? true :data "enc"}}]
+                    true))]
+      (is (match? {:role "assistant"
+                   :content [{:type "redacted_thinking" :data "enc"}]}
+                  (first out))))))
+
 (deftest group-parallel-tool-calls-test
   (testing "single tool call passes through unchanged")
   (is (match?


### PR DESCRIPTION
- [x] I added a entry in changelog under unreleased section.
- [ ] This is not an AI slop.

The fix and regerssion test were generated by Claude. I don't think this is slop, but you can decide. I have read the new code and I understand the fix. I have tested that all unit tests pass, new regression test, and I have been running the patched server succesfully.

## Summary

- Direct Anthropic chats fail on the 2nd+ turn with `400 ... messages.N.content.0.thinking.thinking: Input should be a valid string` when a prior turn produced a thinking block with no content.
- Root cause: a `content_block_start` of type `thinking` with no `thinking_delta` before `content_block_stop` leaves `(:text content)` as `nil`. When that `reason` message is replayed in `normalize-messages`, `:thinking` is serialized as `nil`, which Anthropic rejects.
- Fix: default to `""` — `:thinking (or (:text content) "")` in the `reason` branch of `normalize-messages`.

## Test

Adds `reason-empty-thinking-test` covering nil `:text`, missing `:text` key, present `:text` (preserved), and redacted thinking (unaffected). Verified it fails on the unpatched code (`nil` vs `""`) and passes with the fix. Full suite: 593 tests, 3225 assertions, 0 failures.

Closes #481
