### PR TITLE
Include parent_chat_id in subagent postRequest hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bugfix: subagent `postRequest` hooks now include `parent_chat_id`, letting hooks distinguish primary and subagent completions. (#505)
 - Bugfix: clearer rejected tool-call result wording so models no longer assume a rejected edit was applied; it now states the call did not run and changed nothing. (#507)
 - Bugfix: `ask_user` normalizes the `options` argument so a malformed value (e.g. a stringified options an LLM sometimes emits) no longer reaches clients as broken choices. Accepts string/object arrays, recovers a JSON-encoded string, and drops unusable input.
 

--- a/docs/config/hooks.md
+++ b/docs/config/hooks.md
@@ -272,7 +272,7 @@ Fires after a primary-agent prompt finishes. Also runs for subagents. Primary us
 !!! note
     `postRequest` fires only after LLM responses. Display-only commands (`/hooks`, `/model`, `/costs`) and compaction prompts (`/compact` and auto-compact) do **not** trigger it — use [`postCompact`](#postcompact) for compaction.
 
-- **Input adds** — `response` (last assistant text) and `follow_up_active` (`true` when this turn was triggered by a previous `followUp`).
+- **Input adds** — `response` (last assistant text), `follow_up_active` (`true` when this turn was triggered by a previous `followUp`), and, for subagents, `parent_chat_id`.
 - **Honored output**:
   - `followUp` — start a new LLM turn after this one (see [follow-up turns](#follow-up-turns)).
   - `systemMessage`, `suppressOutput`.

--- a/src/eca/features/chat/lifecycle.clj
+++ b/src/eca/features/chat/lifecycle.clj
@@ -325,11 +325,14 @@
         base-hook-data (assoc-some (f.hooks/chat-hook-data db chat-ctx)
                                    :response response
                                    :follow-up-active (boolean follow-up-active?))
+        post-request-hook-data (assoc-some base-hook-data
+                                           :parent-chat-id (when subagent?
+                                                             (db/parent-chat-id db chat-id)))
         cb {:on-before-action (partial notify-before-hook-action! chat-ctx)
             :on-after-action (fn [result]
                                (notify-after-hook-action! chat-ctx result)
                                (swap! results* conj result))}
-        _ (f.hooks/trigger-if-matches! :postRequest base-hook-data cb db config)
+        _ (f.hooks/trigger-if-matches! :postRequest post-request-hook-data cb db config)
         ;; A successful continue:false on a postRequest hook stops the turn, so
         ;; the remaining relevant hooks must not run. For subagents this means
         ;; subagentPostRequest is skipped, otherwise it could emit side effects
@@ -337,7 +340,7 @@
         post-request-stopped? (boolean (some f.hooks/successful-continue-false? @results*))
         _ (when (and subagent? (not post-request-stopped?))
             (f.hooks/trigger-if-matches! :subagentPostRequest
-                                         (assoc base-hook-data :parent-chat-id (db/parent-chat-id db chat-id))
+                                         post-request-hook-data
                                          cb
                                          db
                                          config))

--- a/test/eca/features/hooks_test.clj
+++ b/test/eca/features/hooks_test.clj
@@ -1864,10 +1864,9 @@
                                :actions [{:type "shell" :shell "echo pr"}]}
                         "spr" {:type "subagentPostRequest"
                                 :actions [{:type "shell" :shell "echo spr"}]}}})
-    (let [fired-types* (atom [])]
+    (let [payloads* (atom [])]
       (with-redefs [f.hooks/run-shell-cmd (fn [{:keys [input]}]
-                                            (let [data (json/parse-string input true)]
-                                              (swap! fired-types* conj (:hook_type data)))
+                                            (swap! payloads* conj (json/parse-string input true))
                                             {:exit 0 :out "" :err nil})]
         (lifecycle/finish-chat-prompt! :idle {:db* (h/db*)
                                               :config (h/config)
@@ -1875,7 +1874,8 @@
                                               :agent "explorer"
                                               :messenger (h/messenger)
                                               :metrics (h/metrics)}))
-      (is (= ["postRequest" "subagentPostRequest"] @fired-types*)))))
+      (is (= ["postRequest" "subagentPostRequest"] (mapv :hook_type @payloads*)))
+      (is (= ["parent-1" "parent-1"] (mapv :parent_chat_id @payloads*))))))
 
 (deftest subagent-postrequest-skipped-when-postrequest-stops-test
   (testing "a successful postRequest continue:false stops the turn and skips subagentPostRequest"


### PR DESCRIPTION
## Summary

- Include `parent_chat_id` in subagent `postRequest` hook payloads.
- Document the subagent-specific field and cover it in hook lifecycle tests.
- Keeps `postRequest` valid for both primary and subagent chats while allowing hooks to distinguish them.

Follow-up to #505.

- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.

🤖 Generated with [ECA](https://eca.dev) (openai/gpt-5.5 - high)