### PR TITLE
Add built-in model variants for glm-5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add built-in variants for `glm-5.2` (case-insensitive): `none`, `medium`, `high`.
+
 ## 0.143.1
 
 - MCP: detect a broken/logged-out session (expired/revoked token, expired session) and re-initialize instead of hanging the tool call until timeout; relies on plumcp 0.2.2 correlating HTTP error responses to the originating request.

--- a/src/eca/config.clj
+++ b/src/eca/config.clj
@@ -82,6 +82,11 @@
    "high" {:reasoning_effort "high"}
    "max" {:reasoning_effort "max"}})
 
+(def ^:private glm-variants
+  {"none" {:reasoning_effort "none"}
+   "high" {:reasoning_effort "high"}
+   "max" {:reasoning_effort "max"}})
+
 (def ^:private initial-config*
   {:providers {"openai" {:api "openai-responses"
                          :url "${env:OPENAI_API_URL:https://api.openai.com}"
@@ -205,7 +210,8 @@
                      ".*gpt[-._]5(?:[-._](?:2|4|5)(?!\\d)|[-._]3[-._]codex)" {:variants openai-variants
                                                                               :excludeProviders ["github-copilot"]}
                      ".*deepseek[-._]v4[-._]pro" {:variants deepseek-variants
-                                                  :api "openai-chat"}}
+                                                  :api "openai-chat"}
+                     "(?i).*glm[-._]5[-._]2" {:variants glm-variants}}
    :mcpTimeoutSeconds 60
    :mcpKeepAliveSeconds 30
    :lspTimeoutSeconds 30


### PR DESCRIPTION
Adds three variant presets (none, medium, high) for glm-5.2 models, matched case-insensitively via a (?i) flag in :variantsByModel so GLM-5.2, Glm_5_2, etc. all resolve to the same variant set.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
