### PR TITLE
fix: skip OAuth refresh when API key overrides auth

### DIFF
--- a/src/eca/features/login.clj
+++ b/src/eca/features/login.clj
@@ -111,13 +111,14 @@
       (on-error (.getMessage e)))))
 
 (defn maybe-renew-auth-token! [{:keys [provider on-renewing on-error]} ctx]
-  (when-let [expires-at (get-in @(:db* ctx) [:auth provider :expires-at])]
-    ;; Renew 60s before expiration to avoid race between check and request
-    (when (<= (long expires-at) (+ 60 (quot (System/currentTimeMillis) 1000)))
-      (when on-renewing
-        (on-renewing))
-      (renew-auth! provider ctx
-                   {:on-error on-error}))))
+  (when-not (f.providers/key-auth-override-warning provider (:config ctx))
+    (when-let [expires-at (get-in @(:db* ctx) [:auth provider :expires-at])]
+      ;; Renew 60s before expiration to avoid race between check and request
+      (when (<= (long expires-at) (+ 60 (quot (System/currentTimeMillis) 1000)))
+        (when on-renewing
+          (on-renewing))
+        (renew-auth! provider ctx
+                     {:on-error on-error})))))
 
 (defn renew-expiring-auth-tokens!
   "Best-effort proactive renewal of any provider auth tokens that are at/near

--- a/test/eca/features/login_test.clj
+++ b/test/eca/features/login_test.clj
@@ -197,3 +197,21 @@
             (is (= "rotated-session" (get-in @db* [:auth "github-copilot" :api-key])))
             (is (= "fresh-session" (get-in @db* [:auth "anthropic" :api-key]))))
           (finally (fs/delete-tree tmpdir)))))))
+
+(deftest maybe-renew-auth-token!-skips-when-configured-key-overrides-oauth-test
+  (testing "an expired saved OAuth token does not block a provider configured with a static key"
+    (let [db* (atom {:auth {"anthropic" {:type :auth/oauth
+                                           :api-key "expired-access"
+                                           :refresh-token "expired-refresh"
+                                           :expires-at 0}}})
+          renew-calls* (atom 0)
+          renewing-calls* (atom 0)]
+      (with-redefs-fn {#'login/renew-auth! (fn [& _]
+                                              (swap! renew-calls* inc))}
+        #(login/maybe-renew-auth-token!
+          {:provider "anthropic"
+           :on-renewing (fn [] (swap! renewing-calls* inc))}
+          {:db* db*
+           :config {:providers {"anthropic" {:key "local-proxy-key"}}}}))
+      (is (zero? @renew-calls*))
+      (is (zero? @renewing-calls*)))))


### PR DESCRIPTION
- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
