### PR TITLE
fix(openai-chat): normalize empty-string tool_call id to nil in strea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix streaming tool calls dropped when provider sends empty-string `id` in subsequent chunks (e.g. DashScope/Qwen Cloud).
 - Truncate oversized failed tool output, preserving full logs on disk instead of overflowing the model context.
 - Honor model output limits in OpenAI-compatible Chat Completions and Ollama requests while preserving `extraPayload` overrides.
 

--- a/src/eca/llm_providers/openai_chat.clj
+++ b/src/eca/llm_providers/openai_chat.clj
@@ -667,7 +667,10 @@
                                     ;; Flush any leftover buffered content before finishing
                                     (flush-content-buffer)
                                     (doseq [tool-call (:tool_calls delta)]
-                                      (let [{:keys [index id function extra_content]} tool-call
+                                      (let [{:keys [index function extra_content]} tool-call
+                                            ;; Normalize empty-string id to nil: some providers (e.g. DashScope/Qwen Cloud)
+                                            ;; send `id: ""` in subsequent chunks instead of omitting the field.
+                                            id (not-empty (:id tool-call))
                                             {name :name args :arguments} function
                                             ;; Extract Google Gemini thought signature if present
                                             thought-signature (get-in extra_content [:google :thought_signature])


### PR DESCRIPTION
DashScope/Qwen Cloud sends `id: ""` in subsequent streaming chunks instead of omitting the field. Since empty string is truthy in Clojure, find-existing-tool-key failed to match by index, causing argument chunks to accumulate under a wrong key. The tool was then executed with empty arguments.

Normalize with `not-empty` so the index-based fallback matching works.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
