### PR TITLE
Make lifecycle hook integration tests portable on Windows

### DIFF
--- a/integration-test/integration/chat/hooks_test.clj
+++ b/integration-test/integration/chat/hooks_test.clj
@@ -124,19 +124,27 @@
       (eca/request!
        (fixture/initialize-request
         {:initializationOptions
-         (hooks-init-options
-          {"session-start" {:type "sessionStart"
-                            :actions [{:type "shell"
-                                       :shell "echo sessionStart >> .eca/hooks-log.txt"}]}
-           "chat-start" {:type "chatStart"
-                         :actions [{:type "shell"
-                                    :shell "printf 'chatStart:%s\\n' \"$(jq -r '.resumed')\" >> .eca/hooks-log.txt"}]}
-           "chat-end" {:type "chatEnd"
-                       :actions [{:type "shell"
-                                  :shell "echo chatEnd >> .eca/hooks-log.txt"}]}
-           "session-end" {:type "sessionEnd"
+          (hooks-init-options
+           {"session-start" {:type "sessionStart"
+                             :actions [{:type "shell"
+                                        :shell (if win?
+                                                 "Add-Content -Encoding ascii -Path .eca/hooks-log.txt -Value 'sessionStart'"
+                                                 "echo sessionStart >> .eca/hooks-log.txt")}]}
+            "chat-start" {:type "chatStart"
                           :actions [{:type "shell"
-                                     :shell "echo sessionEnd >> .eca/hooks-log.txt"}]}})}))
+                                     :shell (if win?
+                                              "$hookInput = $Input | Out-String | ConvertFrom-Json; Add-Content -Encoding ascii -Path .eca/hooks-log.txt -Value ('chatStart:' + $hookInput.resumed.ToString().ToLowerInvariant())"
+                                              "printf 'chatStart:%s\\n' \"$(jq -r '.resumed')\" >> .eca/hooks-log.txt")}]}
+            "chat-end" {:type "chatEnd"
+                        :actions [{:type "shell"
+                                  :shell (if win?
+                                           "Add-Content -Encoding ascii -Path .eca/hooks-log.txt -Value 'chatEnd'"
+                                           "echo chatEnd >> .eca/hooks-log.txt")}]}
+            "session-end" {:type "sessionEnd"
+                           :actions [{:type "shell"
+                                     :shell (if win?
+                                              "Add-Content -Encoding ascii -Path .eca/hooks-log.txt -Value 'sessionEnd'"
+                                              "echo sessionEnd >> .eca/hooks-log.txt")}]}})}))
 
       (eca/notify! (fixture/initialized-notification))
 
@@ -170,11 +178,8 @@
         ;; - chatStart:false (new chat, not resumed)
         ;; - chatEnd
         ;; - sessionEnd
-        (if win? (is (= 5 (count lines))) ;; The used command results in bad encoding in Windows etc...
-            (is (= (if win?
-                     ["??sessionStart\r" "chatStart:false\r" "chatEnd\r" "sessionEnd\r" ""]
-                     ["sessionStart" "chatStart:false" "chatEnd" "sessionEnd"])
-                   lines)))))))
+        (is (= ["sessionStart" "chatStart:false" "chatEnd" "sessionEnd"]
+               lines))))))
 
 (deftest posttoolcall-receives-tool-response-test
   (testing "postToolCall hook receives tool_response and tool_input after tool execution"


### PR DESCRIPTION
> This pull request has no dependencies on other pull requests.

## Problem

The lifecycle hook integration test executed a POSIX-only `printf` and `jq` pipeline
through PowerShell on Windows.

The `chatStart` action failed, while the Windows-specific assertion only counted
malformed encoding-affected lines and did not verify the real lifecycle order.

## Solution

Use native PowerShell JSON parsing and ASCII append operations on Windows while
retaining the existing POSIX implementation on Unix.

Assert the same exact lifecycle sequence on every platform:

1. `sessionStart`
2. `chatStart:false`
3. `chatEnd`
4. `sessionEnd`

## Verification

- `bb integration-test --dev --ns integration.chat.hooks-test` passed on Windows.
- Seven integration tests containing 17 assertions passed.
- No failures or errors occurred on Windows with Temurin JDK 24.
- The complete ECA suite passed with 797 tests and 4,446 assertions using the
  CI-compatible `en-US` JVM locale.
- `git diff --check` passed.