### PR TITLE
Fix OpenAI Responses chats stuck after SSE error events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix OpenAI Responses SSE errors, incomplete responses, and premature stream closes so chats retry or finish instead of staying active.
+
 ## 0.150.1
 
 - Add Claude Opus 5 support.

--- a/src/eca/llm_providers/errors.clj
+++ b/src/eca/llm_providers/errors.clj
@@ -51,6 +51,10 @@
    #"(?i)connection refused"
    #"(?i)UnresolvedAddressException"])
 
+(def ^:private premature-stop-patterns
+  [#"(?i)stream disconnected before completion"
+   #"(?i)stream closed before response\.completed"])
+
 (def ^:private openai-transient-message-pattern
   #"(?i)an error occurred while processing your request\.\s+you can retry your request\b")
 
@@ -91,7 +95,7 @@
   [{:keys [code type message] source :error/source}]
   (when (= :openai-responses source)
     (cond
-      (some #{"server_error"} [code type])
+      (some #{"server_error" "server_is_overloaded"} [code type])
       {:error/type :overloaded}
 
       (some #{"rate_limit_exceeded"} [code type])
@@ -120,6 +124,9 @@
 
       (matches-any-pattern? message rate-limited-patterns)
       {:error/type :rate-limited}
+
+      (matches-any-pattern? message premature-stop-patterns)
+      {:error/type :premature-stop}
 
       (matches-any-pattern? message overloaded-patterns)
       {:error/type :overloaded}

--- a/src/eca/llm_providers/openai.clj
+++ b/src/eca/llm_providers/openai.clj
@@ -171,6 +171,38 @@
                 :request-id request-id
                 :headers response-headers)))
 
+(defn ^:private response-incomplete->error-data [data response-headers]
+  (let [response (:response data)
+        reason (get-in response [:incomplete_details :reason])
+        request-id (some non-blank-str
+                         [(:request-id response)
+                          (:request_id response)
+                          (response-header response-headers "x-request-id")])]
+    (assoc-some {:message (if reason
+                           (format "OpenAI response incomplete: %s" reason)
+                           "OpenAI response incomplete")
+                 :error/type :premature-stop
+                 :error/source :openai-responses
+                 :headers response-headers}
+                :response-id (:id response)
+                :request-id request-id
+                :incomplete-reason reason)))
+
+(defn ^:private stream-error->error-data [data response-headers]
+  (let [error (or (:error data) data)
+        error (if (= "error" (:type error))
+                (dissoc error :type)
+                error)
+        request-id (some non-blank-str
+                         [(:request-id error)
+                          (:request_id error)
+                          (response-header response-headers "x-request-id")])]
+    (assoc-some error
+                :message (or (:message error) "OpenAI response stream failed")
+                :error/source :openai-responses
+                :request-id request-id
+                :headers response-headers)))
+
 (defn ^:private base-responses-request! [{:keys [rid body api-url auth-type url-relative-path api-key account-id on-error on-stream http-client extra-headers cancelled? stream-idle-timeout-seconds]}]
   (let [oauth? (= :auth/oauth auth-type)
         stream? (and on-stream (not= false (:stream body)))
@@ -221,16 +253,45 @@
                 (let [stream-error
                       (with-open [rdr (io/reader body)]
                         (loop [events (seq (llm-util/event-data-seq rdr))]
-                          (when-let [[event data] (first events)]
-                            (set-reading-fn false)
-                            (touch-fn)
-                            (llm-util/log-response logger-tag rid event data)
-                            (if (= "response.failed" event)
-                              (response-failed->error-data data resp-headers)
-                              (do
-                                (on-stream event data resp-headers)
-                                (set-reading-fn true)
-                                (recur (next events)))))))]
+                          (if-let [[event data] (first events)]
+                            (do
+                              (set-reading-fn false)
+                              (touch-fn)
+                              (llm-util/log-response logger-tag rid event data)
+                              (cond
+                                (= "response.failed" event)
+                                (response-failed->error-data data resp-headers)
+
+                                (= "response.incomplete" event)
+                                (response-incomplete->error-data data resp-headers)
+
+                                (= "error" event)
+                                (stream-error->error-data data resp-headers)
+
+                                (= "response.completed" event)
+                                (do
+                                  (on-stream event data resp-headers)
+                                  nil)
+
+                                :else
+                                (do
+                                  (on-stream event data resp-headers)
+                                  (set-reading-fn true)
+                                  (recur (next events)))))
+                            (case @reason*
+                              :cancelled
+                              (throw (ex-info "Stream cancelled" {:silent? true}))
+
+                              :idle-timeout
+                              {:message (format "Stream idle timeout: no data received for %d seconds"
+                                                (or stream-idle-timeout-seconds 120))}
+
+                              (assoc-some
+                               {:message "Stream disconnected before completion: stream closed before response.completed"
+                                :error/type :premature-stop
+                                :error/source :openai-responses
+                                :headers resp-headers}
+                               :request-id (response-header resp-headers "x-request-id"))))))]
                   (when stream-error
                     (on-error stream-error)))
                 (catch java.io.IOException e

--- a/test/eca/llm_providers/errors_test.clj
+++ b/test/eca/llm_providers/errors_test.clj
@@ -151,6 +151,13 @@
                      :type "server_error"
                      :message "Request failed")))))
 
+    (testing "structured server_is_overloaded code is overloaded"
+      (is (= {:error/type :overloaded}
+             (llm-providers.errors/classify-error
+              (assoc responses-error
+                     :code "server_is_overloaded"
+                     :message "Our servers are currently overloaded. Please try again later.")))))
+
     (testing "structured rate_limit_exceeded code is rate limited"
       (is (= {:error/type :rate-limited}
              (llm-providers.errors/classify-error
@@ -162,6 +169,12 @@
       (is (= {:error/type :overloaded}
              (llm-providers.errors/classify-error
               (assoc responses-error :message generic-message)))))
+
+    (testing "stream closed before completion is a premature stop"
+      (is (= {:error/type :premature-stop}
+             (llm-providers.errors/classify-error
+              (assoc responses-error
+                     :message "stream disconnected before completion: stream closed before response.completed")))))
 
     (testing "generic transient message is not applied to unmarked errors"
       (is (= {:error/type :unknown}

--- a/test/eca/llm_providers/openai_test.clj
+++ b/test/eca/llm_providers/openai_test.clj
@@ -484,6 +484,113 @@
       (is (true? (:silent? (ex-data (:exception (first @errors*))))))
       (is (empty? @messages*)))))
 
+(deftest create-response-error-event-test
+  (testing "generic SSE error terminates the stream and invokes error handling"
+    (let [response-headers {"X-Request-ID" ["req_overloaded"]}
+          expected-error {:code "server_is_overloaded"
+                          :message "Our servers are currently overloaded. Please try again later."
+                          :sequence_number 0
+                          :error/source :openai-responses
+                          :request-id "req_overloaded"
+                          :headers response-headers}
+          closed?* (atom false)
+          closed-at-error?* (atom false)
+          errors* (atom [])
+          messages* (atom [])
+          stream-text (str "event: error\n"
+                           "data: {\"type\":\"error\",\"code\":\"server_is_overloaded\",\"message\":\"Our servers are currently overloaded. Please try again later.\",\"sequence_number\":0}\n\n"
+                           "event: response.completed\n"
+                           "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n")
+          stream-body (proxy [java.io.ByteArrayInputStream]
+                              [(.getBytes ^String stream-text java.nio.charset.StandardCharsets/UTF_8)]
+                        (close []
+                          (reset! closed?* true)
+                          (proxy-super close)))]
+      (with-redefs [http/post (fn [_url opts]
+                                (is (= :stream (:as opts)))
+                                {:status 200
+                                 :headers response-headers
+                                 :body stream-body})]
+        (llm-providers.openai/create-response!
+         (base-provider-params)
+         (base-callbacks
+          {:on-error (fn [error]
+                       (reset! closed-at-error?* @closed?*)
+                       (swap! errors* conj error))
+           :on-message-received (fn [message] (swap! messages* conj message))})))
+      (is (= [expected-error] @errors*))
+      (is (true? @closed-at-error?*)
+          "retry/error handling must start only after the errored stream is closed")
+      (is (empty? @messages*)
+          "events after error must not emit a finish message"))))
+
+(deftest create-response-incomplete-event-test
+  (testing "response.incomplete terminates the stream and invokes error handling"
+    (let [response-headers {"X-Request-ID" ["req_incomplete"]}
+          expected-error {:message "OpenAI response incomplete: max_output_tokens"
+                          :error/type :premature-stop
+                          :error/source :openai-responses
+                          :headers response-headers
+                          :response-id "resp_incomplete"
+                          :request-id "req_incomplete"
+                          :incomplete-reason "max_output_tokens"}
+          errors* (atom [])
+          messages* (atom [])
+          stream-text (str "event: response.incomplete\n"
+                           "data: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_incomplete\",\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"}}}\n\n"
+                           "event: response.completed\n"
+                           "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n")]
+      (with-redefs [http/post (fn [_url _opts]
+                                {:status 200
+                                 :headers response-headers
+                                 :body (java.io.ByteArrayInputStream.
+                                        (.getBytes ^String stream-text java.nio.charset.StandardCharsets/UTF_8))})]
+        (llm-providers.openai/create-response!
+         (base-provider-params)
+         (base-callbacks
+          {:on-error (fn [error] (swap! errors* conj error))
+           :on-message-received (fn [message] (swap! messages* conj message))})))
+      (is (= [expected-error] @errors*))
+      (is (empty? @messages*)
+          "events after response.incomplete must not emit a finish message"))))
+
+(deftest create-response-premature-eof-test
+  (testing "EOF before a terminal response event invokes error handling"
+    (let [response-headers {"X-Request-ID" ["req_disconnected"]}
+          expected-error {:message "Stream disconnected before completion: stream closed before response.completed"
+                          :error/type :premature-stop
+                          :error/source :openai-responses
+                          :request-id "req_disconnected"
+                          :headers response-headers}
+          closed?* (atom false)
+          closed-at-error?* (atom false)
+          errors* (atom [])
+          messages* (atom [])
+          stream-text (str "event: response.created\n"
+                           "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_123\",\"status\":\"in_progress\"}}\n\n")
+          stream-body (proxy [java.io.ByteArrayInputStream]
+                              [(.getBytes ^String stream-text java.nio.charset.StandardCharsets/UTF_8)]
+                        (close []
+                          (reset! closed?* true)
+                          (proxy-super close)))]
+      (with-redefs [http/post (fn [_url opts]
+                                (is (= :stream (:as opts)))
+                                {:status 200
+                                 :headers response-headers
+                                 :body stream-body})]
+        (llm-providers.openai/create-response!
+         (base-provider-params)
+         (base-callbacks
+          {:on-error (fn [error]
+                       (reset! closed-at-error?* @closed?*)
+                       (swap! errors* conj error))
+           :on-message-received (fn [message] (swap! messages* conj message))})))
+      (is (= [expected-error] @errors*))
+      (is (true? @closed-at-error?*)
+          "retry/error handling must start only after the disconnected stream is closed")
+      (is (empty? @messages*)
+          "premature EOF must not emit a finish message"))))
+
 (deftest normalize-messages-tool-call-output-image-test
   (let [tool-output-with-image
         {:role "tool_call_output"


### PR DESCRIPTION
## Summary

Handle terminal SSE `error` events from the OpenAI Responses API and route them through ECA's existing error and retry handling.

## Problem

An OpenAI Responses request can return HTTP 200 but terminate with an SSE error instead of `response.completed`, for example:

- Event: `error`
- Code: `server_is_overloaded`

ECA previously handled `response.failed`, but generic SSE `error` events were passed to the stream callback and ignored. When the stream then closed normally, ECA emitted neither an error nor a finish event, leaving the chat marked as active indefinitely.

## Changes

- Treat SSE `error` events as terminal OpenAI Responses errors.
- Preserve structured error fields, response headers, and request IDs.
- Close the response stream before invoking error or retry handling.
- Classify `server_is_overloaded` as a retryable provider overload.
- Integrate the handling with the existing stream cancellation and idle-timeout watchdog.
- Add regression tests covering:
  - HTTP 200 streams ending with an SSE `error`.
  - Ignoring trailing events after the terminal error.
  - Stream closure before error handling.
  - `server_is_overloaded` classification.
  - Compatibility with stream cancellation handling.

## Verification

- 35 tests passed.
- 197 assertions passed.
- No test failures.
- No new `clj-kondo` errors.
- Editor diagnostics are clean.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
