### PR TITLE
**Improve sub-agent failure reporting and make retry policy configurable**

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Return exhausted provider errors and partial output from sub-agents instead of reporting successful empty results.
+- Add provider `retry` config for retry counts, backoff, and chat recovery; no-output retries replay the original request.
 - Fix OpenAI Responses SSE errors, incomplete responses, and premature stream closes so chats retry or finish instead of staying active.
 - Return task status to LLM when changing. #556
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Return exhausted provider errors and partial output from sub-agents instead of reporting successful empty results.
 - Fix OpenAI Responses SSE errors, incomplete responses, and premature stream closes so chats retry or finish instead of staying active.
 - Return task status to LLM when changing. #556
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -694,6 +694,56 @@
             "additionalProperties": false
           }
         },
+        "retry": {
+          "type": "object",
+          "description": "Retry count and exponential backoff policy for transient provider errors. Applies to normal chats and sub-agents.",
+          "markdownDescription": "Retry count and exponential backoff policy for transient provider errors. Applies to normal chats and sub-agents.",
+          "properties": {
+            "maxRetries": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 10,
+              "description": "Maximum retries for rate limits, overloaded providers, and custom retry rules. The initial request is not counted.",
+              "markdownDescription": "Maximum retries for rate limits, overloaded providers, and custom retry rules. The initial request is not counted."
+            },
+            "prematureStopMaxRetries": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 3,
+              "description": "Maximum retries when a stream ends before a terminal completion event. The initial request is not counted.",
+              "markdownDescription": "Maximum retries when a stream ends before a terminal completion event. The initial request is not counted."
+            },
+            "maxAutoContinues": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 3,
+              "description": "Maximum chat-level recovery prompts after partial output or after request-level retries are exhausted. Applies to normal chats and sub-agents.",
+              "markdownDescription": "Maximum chat-level recovery prompts after partial output or after request-level retries are exhausted. Applies to normal chats and sub-agents."
+            },
+            "baseDelayMs": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 2000,
+              "description": "Initial exponential backoff delay in milliseconds. ECA applies jitter from 50% up to 150% of the capped delay.",
+              "markdownDescription": "Initial exponential backoff delay in milliseconds. ECA applies jitter from 50% up to 150% of the capped delay."
+            },
+            "backoffMultiplier": {
+              "type": "number",
+              "minimum": 1,
+              "default": 2,
+              "description": "Multiplier applied to the backoff delay after each retry.",
+              "markdownDescription": "Multiplier applied to the backoff delay after each retry."
+            },
+            "maxDelayMs": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 60000,
+              "description": "Maximum exponential backoff delay before jitter, in milliseconds. Provider-supplied rate-limit reset delays use rateLimitMaxWaitSeconds instead.",
+              "markdownDescription": "Maximum exponential backoff delay before jitter, in milliseconds. Provider-supplied rate-limit reset delays use `rateLimitMaxWaitSeconds` instead."
+            }
+          },
+          "additionalProperties": false
+        },
         "rateLimitMaxWaitSeconds": {
           "type": "integer",
           "minimum": 0,

--- a/docs/config/models.md
+++ b/docs/config/models.md
@@ -400,7 +400,9 @@ Schema:
 | `thinkTagStart`                   | string  | Optional override the think start tag tag for openai-chat (Default: "<think>") api                           | No       |
 | `thinkTagEnd`                     | string  | Optional override the think end tag for openai-chat (Default: "</think>") api                                | No       |
 | `httpClient`                      | map     | Allow customize the http-client for this provider requests, like changing http version                       | No       |
-| `retryRules`                      | array   | Custom retry rules that match by HTTP status and/or error pattern (see [Retry Rules](#retry-rules))    | No       |
+| `retryRules`                      | array   | Custom retry rules that match by HTTP status and/or error pattern (see [Retry Policy and Rules](#retry-policy-and-rules)) | No       |
+| `retry`                           | map     | Retry count and exponential backoff policy for transient errors; applies to normal chats and sub-agents | No       |
+| `rateLimitMaxWaitSeconds`         | integer | Maximum provider-supplied rate-limit reset wait, including ECA's one-second safety buffer (default: `60`) | No       |
 | `extraHeaders`                    | map     | Extra headers sent on all requests to this provider (completion and models list fetch). Model-level `extraHeaders` win on conflicts | No       |
 | `models`                          | map     | Key: model name, value: its config                                                                           | Yes      |
 | `models <model> extraPayload`     | map     | Extra payload sent in body to LLM                                                                            | No       |
@@ -611,9 +613,22 @@ Notes:
 - Authentication priority: a configured `key` (with dynamic string parse support, including `${env:OPENAI_API_KEY}`-style defaults that resolve from environment variables) takes precedence over `/login` (OAuth/subscription) auth, which in turn takes precedence over a bare `<PROVIDER>_API_KEY` env var. A configured/env key can therefore incur paid API usage even when you are logged in.
 - All providers with API key auth can use credential files.
 
-### Retry Rules
+### Retry Policy and Rules
 
-ECA automatically retries requests on common transient errors (429, 500, 502, 503, 529) with exponential backoff. You can define custom retry rules per provider using `retryRules` to handle additional status codes or error patterns.
+ECA automatically retries requests on common transient errors (429, 500, 502, 503, 529), provider overload errors, and premature stream termination. The provider-level `retry` object controls the retry budget and exponential backoff for both normal chats and sub-agents:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `maxRetries` | `10` | Retries for rate limits, overloaded providers, and custom retry rules; excludes the initial request |
+| `prematureStopMaxRetries` | `3` | Retries when a stream ends before a terminal completion event; excludes the initial request |
+| `maxAutoContinues` | `3` | Chat-level recovery prompts after partial output or exhausted request retries; applies to normal chats and sub-agents |
+| `baseDelayMs` | `2000` | Initial backoff delay; ECA applies jitter from 50% to 150% |
+| `backoffMultiplier` | `2` | Multiplier applied after each retry |
+| `maxDelayMs` | `60000` | Backoff cap before jitter; provider reset waits are controlled separately by `rateLimitMaxWaitSeconds` |
+
+A value of `0` for either retry count disables request retries in that category; `maxAutoContinues: 0` disables chat-level recovery prompts. If a provider supplies an explicit rate-limit reset time, that delay takes precedence over exponential backoff and is accepted only when it does not exceed `rateLimitMaxWaitSeconds`.
+
+You can define custom retry rules per provider using `retryRules` to handle additional status codes or error patterns.
 
 Each rule can match by:
 
@@ -630,6 +645,14 @@ At least one of `status` or `errorPattern` is required. When both are specified,
       "api": "openai-chat",
       "url": "${env:MY_COMPANY_API_URL}",
       "key": "${env:MY_COMPANY_API_KEY}",
+      "retry": {
+        "maxRetries": 15,
+        "prematureStopMaxRetries": 5,
+        "maxAutoContinues": 5,
+        "baseDelayMs": 2000,
+        "backoffMultiplier": 2,
+        "maxDelayMs": 60000
+      },
       "retryRules": [
         {"status": 418, "label": "Corporate proxy throttle"},
         {"errorPattern": "capacity.*exceeded", "label": "Capacity exceeded"},

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -39,6 +39,19 @@
    truncated responses (e.g. proxies dropping long streaming connections #547)."
   3)
 
+(defn ^:private prompt-error-data
+  "Returns serializable terminal prompt error details for chat state."
+  [{:keys [message exception status code request-id response-id rate-limit-resets-at]} error-type]
+  (assoc-some {:message (or (shared/not-blank message)
+                            (some-> exception ex-message shared/not-blank)
+                            "Unknown provider error")
+               :error-type error-type}
+              :status status
+              :code code
+              :request-id request-id
+              :response-id response-id
+              :rate-limit-resets-at rate-limit-resets-at))
+
 (defn ^:private tool-output-text [msg]
   (let [contents (get-in msg [:content :output :contents])]
     (reduce (fn [^String acc {:keys [text]}]
@@ -902,7 +915,7 @@
         (logger/info logger-tag "Superseding active prompt" {:chat-id chat-id
                                                              :status (get-in @db* [:chats chat-id :status])}))
       (swap! db* assoc-in [:chats chat-id :status] :running)
-      (swap! db* update-in [:chats chat-id] dissoc :prompt-finished?)
+      (swap! db* update-in [:chats chat-id] dissoc :prompt-finished? :prompt-error)
       (swap! db* assoc-in [:chats chat-id :updated-at] (System/currentTimeMillis))
       (messenger/chat-status-changed messenger {:chat-id chat-id :status :running})
       (lifecycle/trigger-chat-status-hook! chat-ctx)
@@ -1464,6 +1477,8 @@
                                                                                (update chat-ctx :auto-continue-count (fnil inc 0)))))))
                                     (do
                                       (when-not stopping?
+                                        (swap! db* assoc-in [:chats chat-id :prompt-error]
+                                               (prompt-error-data error-data error-type))
                                         (lifecycle/send-content! chat-ctx :system
                                                                  {:type :text
                                                                   :text (if (= :context-overflow error-type)
@@ -1485,6 +1500,8 @@
               (catch Exception e
                 (when-not (:silent? (ex-data e))
                   (logger/error e)
+                  (swap! db* assoc-in [:chats chat-id :prompt-error]
+                         (prompt-error-data {:exception e} :unknown))
                   (swap! db* update-in [:chats chat-id] dissoc :auto-compacting? :compacting?)
                   (when-not (string/blank? @received-msgs*)
                     (add-to-history! {:role "assistant"

--- a/src/eca/features/chat.clj
+++ b/src/eca/features/chat.clj
@@ -34,10 +34,13 @@
 
 (def ^:private logger-tag "[CHAT]")
 
-(def ^:private max-auto-continues
-  "Max times a single prompt chain is auto-continued after interrupted or
-   truncated responses (e.g. proxies dropping long streaming connections #547)."
-  3)
+(def ^:private default-max-auto-continues 3)
+
+(defn ^:private provider-max-auto-continues [config provider]
+  (let [configured (get-in config [:providers provider :retry :maxAutoContinues])]
+    (if (and (integer? configured) (not (neg? configured)))
+      (long configured)
+      default-max-auto-continues)))
 
 (defn ^:private prompt-error-data
   "Returns serializable terminal prompt error details for chat state."
@@ -935,6 +938,7 @@
             model-capabilities (get-in db [:models full-model])
             provider-auth (get-in @db* [:auth provider])
             all-tools (f.tools/all-tools chat-id agent @db* config)
+            auto-continue-limit (provider-max-auto-continues config provider)
             received-msgs* (atom "")
             reasonings* (atom {})
             server-tool-times* (atom {})
@@ -1154,7 +1158,7 @@
                                                             (not (string/blank? response-text))
                                                             (or (:premature? msg)
                                                                 (truncated-response? response-text))
-                                                            (< (:auto-continue-count chat-ctx 0) max-auto-continues)
+                                                            (< (:auto-continue-count chat-ctx 0) auto-continue-limit)
                                                             (not (or (:on-finished-side-effect chat-ctx)
                                                                      (:on-after-finish! chat-ctx))))
                                                      (do
@@ -1443,10 +1447,24 @@
                                 (let [partial-text @received-msgs*
                                       transient-error? (contains? #{:overloaded :premature-stop} error-type)
                                       stopping? (identical? :stopping (get-in @db* [:chats chat-id :status]))
+                                      user-messages-recorded? (boolean
+                                                               (when-let [user-content-id (:user-content-id chat-ctx)]
+                                                                 (some #(= user-content-id (:content-id %))
+                                                                       (get-in @db* [:chats chat-id :messages]))))
+                                      continue-existing-response? (or (not (string/blank? partial-text))
+                                                                      user-messages-recorded?)
+                                      retry-messages (if continue-existing-response?
+                                                       [{:role "user"
+                                                         :content [{:type :text
+                                                                    :text "Your previous response was interrupted mid-stream. Continue from where you left off, do not redo completed steps."}]}]
+                                                       user-messages)
+                                      retry-source-type (if continue-existing-response?
+                                                          :auto-continue
+                                                          :transient-error-retry)
                                       can-auto-continue? (and (not stopping?)
                                                               (or transient-error?
                                                                   (string/includes? (or message "") "idle timeout"))
-                                                              (< (:auto-continue-count chat-ctx 0) max-auto-continues)
+                                                              (< (:auto-continue-count chat-ctx 0) auto-continue-limit)
                                                               (not (or (:on-finished-side-effect chat-ctx)
                                                                        (:on-after-finish! chat-ctx)))
                                                               (not compacting?))]
@@ -1460,7 +1478,12 @@
                                       (logger/info logger-tag "Transient error during response, auto-continuing"
                                                    {:chat-id chat-id :error-type error-type})
                                       (lifecycle/send-content! chat-ctx :system
-                                                               {:type :progress :state :running :text (str (or message "Connection interrupted") ", continuing...")})
+                                                               {:type :progress
+                                                                :state :running
+                                                                :text (str (or message "Connection interrupted")
+                                                                           (if continue-existing-response?
+                                                                             ", continuing..."
+                                                                             ", retrying original request..."))})
                                       (swap! db* assoc-in [:chats chat-id :auto-compacting?] true)
                                       (lifecycle/finish-chat-prompt! :idle
                                                                      (assoc chat-ctx
@@ -1470,10 +1493,8 @@
                                                                             :on-after-finish!
                                                                             (fn []
                                                                               (prompt-messages!
-                                                                               [{:role "user"
-                                                                                 :content [{:type :text
-                                                                                            :text "Your previous response was interrupted mid-stream. Continue from where you left off, do not redo completed steps."}]}]
-                                                                               :auto-continue
+                                                                               retry-messages
+                                                                               retry-source-type
                                                                                (update chat-ctx :auto-continue-count (fnil inc 0)))))))
                                     (do
                                       (when-not stopping?

--- a/src/eca/features/tools/agent.clj
+++ b/src/eca/features/tools/agent.clj
@@ -47,20 +47,43 @@
 (defn ^:private max-steps [subagent]
   (:max-steps subagent))
 
+(defn ^:private extract-final-assistant-text
+  "Extracts text from the final assistant message, or nil when none exists."
+  [messages]
+  (some->> messages
+           (filter #(= "assistant" (:role %)))
+           (map :content)
+           (filter seq)
+           last
+           (filter #(= :text (:type %)))
+           (map :text)
+           (str/join "\n")
+           not-empty))
+
 (defn ^:private extract-final-summary
   "Extract the final assistant message as summary from chat messages."
   [messages]
-  (let [assistant-messages (->> messages
-                                (filter #(= "assistant" (:role %)))
-                                (map :content)
-                                (filter seq))]
-    (if (seq assistant-messages)
-      (let [last-content (last assistant-messages)]
-        (->> last-content
-             (filter #(= :text (:type %)))
-             (map :text)
-             (str/join "\n")))
-      "Agent completed without producing output.")))
+  (or (extract-final-assistant-text messages)
+      "Agent completed without producing output."))
+
+(defn ^:private failed-agent-result [agent-name prompt-error partial-output]
+  (let [{:keys [message error-type status code request-id response-id]} prompt-error]
+    {:error true
+     :contents [{:type :text
+                 :text (str "## Agent '" agent-name "' Failed\n\n"
+                            (or message "The sub-agent prompt failed.")
+                            (when error-type
+                              (str "\n\nError type: " (name error-type)))
+                            (when status
+                              (str "\nStatus: " status))
+                            (when code
+                              (str "\nCode: " code))
+                            (when request-id
+                              (str "\nRequest ID: " request-id))
+                            (when response-id
+                              (str "\nResponse ID: " response-id))
+                            (when partial-output
+                              (str "\n\n## Partial result\n\n" partial-output)))}]}))
 
 (defn ^:private ->subagent-chat-id
   "Generate a deterministic subagent chat id from the tool-call-id."
@@ -242,16 +265,32 @@
                   (#{:idle :error} status)
                   (let [messages (get-in db [:chats subagent-chat-id :messages] [])
                         summary (extract-final-summary messages)
+                        partial-output (extract-final-assistant-text messages)
+                        prompt-error (get-in db [:chats subagent-chat-id :prompt-error])
+                        failed? (boolean (or (= :error status) prompt-error))
                         max-steps-reached? (get-in db [:chats subagent-chat-id :max-steps-reached?])]
-                    (if max-steps-reached?
+                    (cond
+                      max-steps-reached?
                       (logger/info logger-tag (format "Agent '%s' halted after reaching max steps (%d)" agent-name max-steps-limit))
+
+                      failed?
+                      (logger/warn logger-tag (format "Agent '%s' failed after %d steps: %s"
+                                                      agent-name current-step (:message prompt-error)))
+
+                      :else
                       (logger/info logger-tag (format "Agent '%s' completed after %d steps" agent-name current-step)))
                     (swap! db* assoc-in [:chats chat-id :tool-calls tool-call-id :subagent-final-step] current-step)
-                    (if max-steps-reached?
+                    (cond
+                      max-steps-reached?
                       {:error true
                        :contents [{:type :text
                                    :text (format "## Agent '%s' Halted\n\nAgent was halted because it reached the maximum number of steps (%d). The result below may be incomplete.\n\n%s"
                                                  agent-name max-steps-limit summary)}]}
+
+                      failed?
+                      (failed-agent-result agent-name prompt-error partial-output)
+
+                      :else
                       {:error false
                        :contents [{:type :text
                                    :text (format "## Agent '%s' Result\n\n%s" agent-name summary)}]}))

--- a/src/eca/llm_api.clj
+++ b/src/eca/llm_api.clj
@@ -37,20 +37,44 @@
 (def ^:private default-max-retries 10)
 (def ^:private premature-stop-max-retries 3)
 (def ^:private default-base-delay-ms 2000)
-(def ^:private default-backoff-multiplier 2)
+(def ^:private default-backoff-multiplier 2.0)
 (def ^:private max-delay-ms 60000)
 (def ^:private default-rate-limit-max-wait-seconds 60)
 (def ^:private rate-limit-wait-buffer-ms 1000)
 (def ^:private cancel-check-interval-ms 100)
 
+(defn ^:private non-negative-long [value default]
+  (if (and (number? value) (not (neg? value)))
+    (long value)
+    default))
+
+(defn ^:private retry-policy [provider-config error-type]
+  (let [retry-config (:retry provider-config)]
+    {:max-retries (non-negative-long
+                   (if (= :premature-stop error-type)
+                     (:prematureStopMaxRetries retry-config)
+                     (:maxRetries retry-config))
+                   (if (= :premature-stop error-type)
+                     premature-stop-max-retries
+                     default-max-retries))
+     :base-delay-ms (non-negative-long (:baseDelayMs retry-config) default-base-delay-ms)
+     :backoff-multiplier (if (and (number? (:backoffMultiplier retry-config))
+                                  (>= (:backoffMultiplier retry-config) 1))
+                           (double (:backoffMultiplier retry-config))
+                           default-backoff-multiplier)
+     :max-delay-ms (non-negative-long (:maxDelayMs retry-config) max-delay-ms)}))
+
 (defn ^:private retry-delay-ms
-  "Computes exponential backoff delay with jitter for the given attempt (0-based).
-   Capped at `max-delay-ms` to avoid excessively long waits."
-  [attempt]
-  (let [base (long (* default-base-delay-ms (Math/pow default-backoff-multiplier (long attempt))))
-        capped (min base max-delay-ms)
-        jitter (long (* capped (rand)))]
-    (+ (quot capped 2) jitter)))
+  "Computes exponential backoff delay with jitter for the given attempt (0-based)."
+  ([attempt]
+   (retry-delay-ms attempt {:base-delay-ms default-base-delay-ms
+                            :backoff-multiplier default-backoff-multiplier
+                            :max-delay-ms max-delay-ms}))
+  ([attempt {:keys [base-delay-ms backoff-multiplier max-delay-ms]}]
+   (let [base (long (* base-delay-ms (Math/pow backoff-multiplier (long attempt))))
+         capped (min base max-delay-ms)
+         jitter (long (* capped (rand)))]
+     (+ (quot capped 2) jitter))))
 
 (defn ^:private sleep-with-cancel
   "Sleeps for `duration-ms`, checking `cancelled-fn?` every 100ms.
@@ -520,9 +544,8 @@
         maybe-retry (fn [error-data attempt on-give-up retry-prompt-fn]
                       (let [{error-type :error/type
                              :as classified} (llm-providers.errors/classify-error error-data retry-rules)
-                            max-retries (if (= :premature-stop error-type)
-                                          premature-stop-max-retries
-                                          default-max-retries)
+                            policy (retry-policy provider-config error-type)
+                            max-retries (:max-retries policy)
                             rl-wait (when (= :rate-limited error-type)
                                       (llm-providers.errors/rate-limit-wait (:headers error-data)
                                                                             (:body error-data)
@@ -542,7 +565,7 @@
                                  (not @first-response-received*)
                                  (not (cancelled?)))
                           (let [delay-ms (or rate-limit-delay-ms
-                                             (retry-delay-ms attempt))]
+                                             (retry-delay-ms attempt policy))]
                             (logger/info logger-tag
                                          (format "Retryable error (attempt %d/%d), retrying in %ds%s"
                                                  (inc attempt) max-retries (quot delay-ms 1000)
@@ -555,6 +578,7 @@
                                            :max-retries max-retries
                                            :delay-ms delay-ms
                                            :resets-at (:resets-at rl-wait)
+                                           :policy policy
                                            :error-data error-data
                                            :classified classified})
                                 (catch Exception e

--- a/test/eca/features/chat_test.clj
+++ b/test/eca/features/chat_test.clj
@@ -185,6 +185,45 @@
                    :status 503}
                   (get-in (h/db) [:chats chat-id :prompt-error]))))))
 
+(deftest provider-max-auto-continues-test
+  (is (= 3 (#'f.chat/provider-max-auto-continues {} "openai")))
+  (is (= 7 (#'f.chat/provider-max-auto-continues
+            {:providers {"openai" {:retry {:maxAutoContinues 7}}}}
+            "openai")))
+  (is (= 0 (#'f.chat/provider-max-auto-continues
+            {:providers {"openai" {:retry {:maxAutoContinues 0}}}}
+            "openai")))
+  (is (= 3 (#'f.chat/provider-max-auto-continues
+            {:providers {"openai" {:retry {:maxAutoContinues -1}}}}
+            "openai"))))
+
+(deftest transient-error-recovery-test
+  (testing "retries the original request when overload happens before model output"
+    (h/reset-components!)
+    (let [requests* (atom [])
+          {:keys [chat-id]}
+          (prompt!
+           {:message "Investigate the failure"}
+           {:all-tools-mock (constantly [])
+            :api-mock
+            (fn [{:keys [user-messages on-first-response-received on-message-received on-error]}]
+              (let [attempt (count (swap! requests* conj user-messages))]
+                (if (= 1 attempt)
+                  (on-error {:code "server_is_overloaded"
+                             :message "Our servers are currently overloaded. Please try again later."
+                             :error/source :openai-responses})
+                  (do
+                    (on-first-response-received {:type :text :text "Recovered"})
+                    (on-message-received {:type :text :text "Recovered"})
+                    (on-message-received {:type :finish})))))})]
+      (is (= 2 (count @requests*)))
+      (is (= (first @requests*) (second @requests*))
+          "a no-output retry must replay the original task, not a contextless continuation")
+      (is (match? [{:role "user" :content [{:type :text :text "Investigate the failure"}]}
+                   {:role "assistant" :content [{:type :text :text "Recovered"}]}]
+                  (get-in (h/db) [:chats chat-id :messages])))
+      (is (nil? (get-in (h/db) [:chats chat-id :prompt-error]))))))
+
 (deftest prompt-multiple-text-interaction-test
   (testing "Chat history"
     (h/reset-components!)

--- a/test/eca/features/chat_test.clj
+++ b/test/eca/features/chat_test.clj
@@ -165,6 +165,26 @@
               :role :system}]}
            (h/messages))))))
 
+(deftest terminal-prompt-error-test
+  (testing "records a terminal provider error after chat recovery is exhausted"
+    (h/reset-components!)
+    (let [attempts* (atom 0)
+          {:keys [chat-id]}
+          (prompt!
+           {:message "Investigate the failure"}
+           {:all-tools-mock (constantly [])
+            :api-mock
+            (fn [{:keys [on-error]}]
+              (swap! attempts* inc)
+              (on-error {:status 503
+                         :body "{\"error\":{\"message\":\"auth_unavailable: no auth available\",\"type\":\"server_error\",\"code\":\"internal_server_error\"}}"
+                         :message "OpenAI response status: 503 body: auth_unavailable"}))})]
+      (is (= 4 @attempts*) "one initial request plus three chat-level recovery attempts")
+      (is (match? {:message "OpenAI response status: 503 body: auth_unavailable"
+                   :error-type :overloaded
+                   :status 503}
+                  (get-in (h/db) [:chats chat-id :prompt-error]))))))
+
 (deftest prompt-multiple-text-interaction-test
   (testing "Chat history"
     (h/reset-components!)

--- a/test/eca/features/tools/agent_test.clj
+++ b/test/eca/features/tools/agent_test.clj
@@ -273,6 +273,61 @@
           (testing "preserves subagent chat for resume replay"
             (is (some? (get-in @db* [:chats subagent-chat-id])))))))))
 
+(deftest spawn-agent-provider-error-test
+  (testing "returns a failed tool result with provider error and partial output"
+    (let [db* (atom {:chats {"chat-1" {:id "chat-1" :model "test/model"}}})
+          subagent-chat-id "subagent-tc-error"]
+      (with-redefs [requiring-resolve
+                    (fn [sym]
+                      (case sym
+                        eca.features.chat/prompt
+                        (fn [_params _db* _messenger _config _metrics]
+                          (swap! db* assoc-in [:chats subagent-chat-id :status] :idle)
+                          (swap! db* assoc-in [:chats subagent-chat-id :prompt-error]
+                                 {:message "Our servers are currently overloaded. Please try again later."
+                                  :error-type :overloaded
+                                  :request-id "req_overloaded"})
+                          (swap! db* assoc-in [:chats subagent-chat-id :messages]
+                                 [{:role "assistant"
+                                   :content [{:type :text :text "Partial findings"}]}]))
+                        (clojure.lang.RT/var (namespace sym) (name sym))))]
+        (let [result ((spawn-handler)
+                      {"agent" "explorer" "task" "find files" "activity" "exploring"}
+                      {:db* db*
+                       :config test-config
+                       :messenger (h/messenger)
+                       :metrics (h/metrics)
+                       :chat-id "chat-1"
+                       :tool-call-id "tc-error"
+                       :call-state-fn (constantly {:status :executing})})]
+          (is (match? {:error true
+                       :contents [{:type :text
+                                   :text #"(?s)Failed.*servers are currently overloaded.*Error type: overloaded.*Request ID: req_overloaded.*Partial result.*Partial findings"}]}
+                      result))))))
+
+  (testing "an error status without structured details still returns failure"
+    (let [db* (atom {:chats {"chat-1" {:id "chat-1" :model "test/model"}}})
+          subagent-chat-id "subagent-tc-error-status"]
+      (with-redefs [requiring-resolve
+                    (fn [sym]
+                      (case sym
+                        eca.features.chat/prompt
+                        (fn [_params _db* _messenger _config _metrics]
+                          (swap! db* assoc-in [:chats subagent-chat-id :status] :error))
+                        (clojure.lang.RT/var (namespace sym) (name sym))))]
+        (let [result ((spawn-handler)
+                      {"agent" "general" "task" "investigate"}
+                      {:db* db*
+                       :config test-config
+                       :messenger (h/messenger)
+                       :metrics (h/metrics)
+                       :chat-id "chat-1"
+                       :tool-call-id "tc-error-status"
+                       :call-state-fn (constantly {:status :executing})})]
+          (is (match? {:error true
+                       :contents [{:text #"sub-agent prompt failed"}]}
+                      result)))))))
+
 (deftest spawn-agent-trust-propagation-test
   (testing "forwards trust to subagent chat/prompt"
     (let [db* (atom {:chats {"chat-1" {:id "chat-1" :model "test/model"}}})

--- a/test/eca/llm_api_test.clj
+++ b/test/eca/llm_api_test.clj
@@ -589,7 +589,50 @@
   (testing "capped at max-delay-ms for high attempts"
     (dotimes [_ 50]
       (let [d9 (#'llm-api/retry-delay-ms 9)]
-        (is (<= 30000 d9 90000) "attempt 9: capped at 60s base")))))
+        (is (<= 30000 d9 90000) "attempt 9: capped at 60s base"))))
+
+  (testing "uses configured base, multiplier, and cap"
+    (with-redefs [clojure.core/rand (constantly 0)]
+      (let [policy {:base-delay-ms 100
+                    :backoff-multiplier 3.0
+                    :max-delay-ms 250}]
+        (is (= 50 (#'llm-api/retry-delay-ms 0 policy)))
+        (is (= 125 (#'llm-api/retry-delay-ms 1 policy)))
+        (is (= 125 (#'llm-api/retry-delay-ms 2 policy)))))))
+
+(deftest retry-policy-test
+  (testing "defaults preserve existing retry behavior"
+    (is (= {:max-retries 10
+            :base-delay-ms 2000
+            :backoff-multiplier 2.0
+            :max-delay-ms 60000}
+           (#'llm-api/retry-policy {} :overloaded)))
+    (is (= 3 (:max-retries (#'llm-api/retry-policy {} :premature-stop)))))
+
+  (testing "provider retry configuration overrides the defaults"
+    (let [provider-config {:retry {:maxRetries 6
+                                   :prematureStopMaxRetries 4
+                                   :baseDelayMs 500
+                                   :backoffMultiplier 1.5
+                                   :maxDelayMs 10000}}]
+      (is (= {:max-retries 6
+              :base-delay-ms 500
+              :backoff-multiplier 1.5
+              :max-delay-ms 10000}
+             (#'llm-api/retry-policy provider-config :overloaded)))
+      (is (= 4 (:max-retries (#'llm-api/retry-policy provider-config :premature-stop))))))
+
+  (testing "invalid values fall back to safe defaults"
+    (let [policy (#'llm-api/retry-policy
+                  {:retry {:maxRetries -1
+                           :baseDelayMs -2
+                           :backoffMultiplier 0
+                           :maxDelayMs -3}}
+                  :overloaded)]
+      (is (= 10 (:max-retries policy)))
+      (is (= 2000 (:base-delay-ms policy)))
+      (is (= 2.0 (:backoff-multiplier policy)))
+      (is (= 60000 (:max-delay-ms policy))))))
 
 (deftest sleep-with-cancel-test
   (testing "completes when not cancelled"
@@ -912,6 +955,45 @@
            :on-message-received identity})))
       (is (= 4 @attempt*) "1 initial + 3 retries")
       (is (true? @on-error-called*)))))
+
+(deftest configured-retry-policy-test
+  (testing "uses configured retry count and backoff for a 503 auth_unavailable response"
+    (let [attempt* (atom 0)
+          delays* (atom [])
+          retry-events* (atom [])
+          final-error* (atom nil)
+          error {:status 503
+                 :body "{\"error\":{\"message\":\"auth_unavailable: no auth available (providers=codex, model=gpt-5.6-sol)\",\"type\":\"server_error\",\"code\":\"internal_server_error\"}}"
+                 :message "OpenAI response status: 503 body: auth_unavailable"}]
+      (with-redefs [eca.llm-api/prompt! (fn [_]
+                                          (swap! attempt* inc)
+                                          {:error error})
+                    clojure.core/rand (constantly 0)
+                    eca.llm-api/sleep-with-cancel (fn [delay-ms _]
+                                                    (swap! delays* conj delay-ms)
+                                                    true)]
+        (llm-api/sync-or-async-prompt!
+         (make-prompt-opts
+          {:stream false
+           :config {:providers {"anthropic" {:key "test-key"
+                                               :url "http://test"
+                                               :retry {:maxRetries 2
+                                                       :baseDelayMs 100
+                                                       :backoffMultiplier 3
+                                                       :maxDelayMs 250}
+                                               :models {"claude-sonnet-4-6" {:extraPayload {:stream false}}}}}}
+           :on-retry (fn [event] (swap! retry-events* conj event))
+           :on-error #(reset! final-error* %)
+           :on-message-received identity})))
+      (is (= 3 @attempt*) "one initial request plus two configured retries")
+      (is (= [50 125] @delays*))
+      (is (= 2 (count @retry-events*)))
+      (is (= {:max-retries 2
+              :base-delay-ms 100
+              :backoff-multiplier 3.0
+              :max-delay-ms 250}
+             (:policy (first @retry-events*))))
+      (is (= error @final-error*)))))
 
 (deftest sync-retry-cancelled-test
   (testing "stops retrying when cancelled"


### PR DESCRIPTION
## Summary

Improve ECA’s resilience to transient provider failures, particularly for sub-agents.

Previously, a sub-agent that exhausted provider retries could be reported as successfully completed without output. Additionally, retry counts, backoff timing, and chat-level recovery attempts were hard-coded.

## Changes

### Sub-agent failure reporting

- Persist terminal provider errors in chat state.
- Clear stale prompt errors when starting a new prompt.
- Return `error: true` when a sub-agent fails instead of reporting a successful empty result.
- Include available failure details in the `spawn_agent` result:
  - provider error message and type
  - HTTP status and error code
  - request and response IDs
  - partial assistant output

### Retry resilience

- Add provider-level `retry` configuration:
  - `maxRetries`
  - `prematureStopMaxRetries`
  - `maxAutoContinues`
  - `baseDelayMs`
  - `backoffMultiplier`
  - `maxDelayMs`
- Preserve the existing retry behavior as defaults.
- Replay the original request when a transient failure occurs before any model output.
- Continue from existing work only when output, reasoning, or other response activity was already received.
- Continue using `rateLimitMaxWaitSeconds` for provider-supplied rate-limit reset delays.
- Include the effective retry policy in retry callback metadata.

Example:

```json
{
  "providers": {
    "openai": {
      "retry": {
        "maxRetries": 15,
        "prematureStopMaxRetries": 5,
        "maxAutoContinues": 5,
        "baseDelayMs": 2000,
        "backoffMultiplier": 2,
        "maxDelayMs": 60000
      },
      "rateLimitMaxWaitSeconds": 60
    }
  }
}
```

## Motivation

Transient errors such as OpenAI `server_is_overloaded` and HTTP 503 `auth_unavailable` responses should not cause sub-agents to silently finish without a result.

ECA now retries these failures according to a configurable policy. If recovery is ultimately exhausted, the parent agent receives an explicit failed tool result with useful diagnostics and any partial work.

## Testing

- Added regression coverage for failed sub-agent result propagation.
- Added coverage for preserving partial sub-agent output.
- Added coverage for terminal prompt error persistence.
- Added coverage for replaying the original request after a no-output failure.
- Added coverage for configurable retry counts and exponential backoff.
- Added coverage for HTTP 503 `auth_unavailable` responses.
- Added configuration schema validation for the new retry policy.
- Full `bb test` suite passes.
- Editor diagnostics report no issues.
- `clj-kondo` reports no errors; existing unrelated warnings remain.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
