### PR TITLE
feat: parse token metrics when using ollama provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Keep `compact_chat` in the tool schema across normal and compact requests, preserving prompt-cache prefixes while rejecting calls outside active compaction.
 
+- Provide token metrics for ollama provider. #567.
+
 ## 0.152.0
 
 - Share chat history across git worktrees of the same repo, and merge workspace cache writes from concurrent servers instead of overwriting. #558

--- a/src/eca/llm_providers/ollama.clj
+++ b/src/eca/llm_providers/ollama.clj
@@ -164,7 +164,7 @@
 (defn chat! [{:keys [model user-messages reason? instructions api-url past-messages tools max-output-tokens
                      extra-headers extra-payload cancelled? stream-idle-timeout-seconds]}
              {:keys [on-message-received on-error on-prepare-tool-call on-tools-called
-                     on-reason] :as callbacks}]
+                     on-reason on-usage-updated] :as callbacks}]
   (let [messages (concat
                   (normalize-messages (concat [{:role "system" :content instructions}] past-messages))
                   (normalize-messages user-messages))
@@ -182,7 +182,7 @@
         tool-calls* (atom {})
         on-stream-fn (when stream?
                        (fn handle-stream [rid _event data reasoning?* reason-id]
-                         (let [{:keys [message done_reason]} data]
+                         (let [{:keys [message done_reason prompt_eval_count eval_count]} data]
                            (cond
                              (seq (:tool_calls message))
                              (let [function (:function (first (seq (:tool_calls message))))
@@ -194,6 +194,10 @@
                                (swap! tool-calls* assoc rid tool-call))
 
                              done_reason
+                             (do
+                               (when (and on-usage-updated (or prompt_eval_count eval_count))
+                                 (on-usage-updated {:input-tokens (or prompt_eval_count 0)
+                                                    :output-tokens (or eval_count 0)}))
                              (if-let [tool-call (get @tool-calls* rid)]
                                  ;; TODO support multiple tool calls
                                (when-let [{:keys [new-messages tools]} (on-tools-called [tool-call])]
@@ -210,7 +214,7 @@
                                      :on-error on-error
                                      :on-stream handle-stream})))
                                (on-message-received {:type :finish
-                                                     :finish-reason done_reason}))
+                                                     :finish-reason done_reason})))
 
                              message
                              (if (:thinking message)


### PR DESCRIPTION
Close #567.

Ollama provides token metrics in the JSON response:
```json
{
  "prompt_eval_count": 16,
  "eval_count": 224
}
```
Those metrics are parsed and then passed upwards as `:input-tokens` and `:ouput-tokens`.


- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.
