### PR TITLE
fix: classify quota-exhausted 429 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Stop retrying provider 429 errors that report exhausted usage or billing quota. #405
 - Add `gpt-6-astra` support: built-in variants `low`, `medium`, `high`, `xhigh`, `max` (no `none`), Codex Lite/context fallbacks, web search and image generation.
 
 ## 0.158.1

--- a/src/eca/llm_providers/errors.clj
+++ b/src/eca/llm_providers/errors.clj
@@ -40,6 +40,12 @@
    #"(?i)throttl"
    #"(?i)overloaded_error"])
 
+(def ^:private quota-exhausted-patterns
+  "Provider error codes that indicate an exhausted usage or billing quota, not a transient rate limit."
+  [#"(?i)usage_limit_reached"
+   #"(?i)insufficient_quota"
+   #"(?i)billing_hard_limit_reached"])
+
 (def ^:private overloaded-patterns
   "Regex patterns matching transient connection/infrastructure errors across providers."
   [#"(?i)remote host terminated the handshake"
@@ -59,8 +65,11 @@
 (def ^:private openai-transient-message-pattern
   #"(?i)an error occurred while processing your request\.\s+you can retry your request\b")
 
-(defn ^:private matches-any-pattern? [^String text patterns]
-  (when text
+(defn ^:private matches-any-pattern? [text patterns]
+  (when-let [text (cond
+                    (string? text) text
+                    (map? text) (pr-str text)
+                    :else nil)]
     (some #(re-find % text) patterns)))
 
 (defn ^:private classify-by-status-and-body
@@ -76,6 +85,10 @@
 
     (= 413 status)
     {:error/type :context-overflow}
+
+    (and (= 429 status)
+         (matches-any-pattern? body quota-exhausted-patterns))
+    {:error/type :quota-exhausted}
 
     (= 429 status)
     {:error/type :rate-limited}
@@ -98,6 +111,9 @@
     (cond
       (some #{"server_error" "server_is_overloaded"} [code type])
       {:error/type :overloaded}
+
+      (some #{"usage_limit_reached" "insufficient_quota" "billing_hard_limit_reached"} [code type])
+      {:error/type :quota-exhausted}
 
       (some #{"rate_limit_exceeded"} [code type])
       {:error/type :rate-limited}
@@ -122,6 +138,9 @@
 
       (matches-any-pattern? message invalid-image-patterns)
       {:error/type :invalid-image}
+
+      (matches-any-pattern? message quota-exhausted-patterns)
+      {:error/type :quota-exhausted}
 
       (matches-any-pattern? message rate-limited-patterns)
       {:error/type :rate-limited}
@@ -186,7 +205,8 @@
      :retryable-custom  — matched a user-configured retry rule (with optional :error/label)
      :context-overflow  — prompt exceeds model context window
      :invalid-image     — provider rejected an image in the request (e.g. too small)
-     :rate-limited      — 429 or rate limit pattern in body/message
+     :quota-exhausted   — exhausted usage or billing quota reported by a provider
+     :rate-limited      — transient 429 or rate limit pattern in body/message
      :overloaded        — provider overloaded (503, 529, etc.)
      :network           — connection-level failure (DNS, connect refused/timeout, dropped)
      :auth              — authentication/authorization failure (401, 403)

--- a/test/eca/llm_api_test.clj
+++ b/test/eca/llm_api_test.clj
@@ -928,8 +928,8 @@
         (is (= 8000 (:delay-ms event)))
         (is (number? (:resets-at event)))))))
 
-(deftest sync-rate-limit-default-max-wait-test
-  (testing "default rateLimitMaxWaitSeconds rejects a long Codex usage-limit reset"
+(deftest sync-quota-exhausted-skips-reset-wait-test
+  (testing "quota exhaustion does not retry even when the provider supplies a reset time"
     (let [attempt* (atom 0)
           error* (atom nil)
           slept* (atom [])]
@@ -950,7 +950,7 @@
            :on-message-received identity})))
       (is (= 1 @attempt*))
       (is (empty? @slept*))
-      (is (number? (:rate-limit-resets-at @error*))))))
+      (is (nil? (:rate-limit-resets-at @error*))))))
 
 (deftest rate-limit-default-max-wait-buffer-boundary-test
   (testing "59-second provider reset is allowed because the buffered delay is exactly 60 seconds"

--- a/test/eca/llm_providers/errors_test.clj
+++ b/test/eca/llm_providers/errors_test.clj
@@ -143,6 +143,38 @@
            (llm-providers.errors/classify-error
             {:message "rate limit exceeded, please retry"})))))
 
+(deftest classify-error-quota-exhausted-test
+  (testing "OpenAI quota and billing codes in 429 response bodies are not transient rate limits"
+    (doseq [code ["usage_limit_reached" "insufficient_quota" "billing_hard_limit_reached"]]
+      (is (= {:error/type :quota-exhausted}
+             (llm-providers.errors/classify-error
+              {:status 429
+               :body {:error {:type code}}
+               :message "OpenAI response status: 429"}))
+          code)))
+
+  (testing "quota code in an unstructured stream error is not retried"
+    (let [error-data {:message "OpenAI error: insufficient_quota"}]
+      (is (= {:error/type :quota-exhausted}
+             (llm-providers.errors/classify-error error-data)))
+      (is (false? (llm-providers.errors/retryable? error-data)))))
+
+  (testing "OpenAI Responses quota code is not retried"
+    (let [error-data {:error/source :openai-responses
+                      :code "usage_limit_reached"
+                      :message "Request failed"}]
+      (is (= {:error/type :quota-exhausted}
+             (llm-providers.errors/classify-error error-data)))
+      (is (false? (llm-providers.errors/retryable? error-data)))))
+
+  (testing "ordinary rate_limit_exceeded remains retryable"
+    (let [error-data {:status 429
+                      :body {:error {:type "rate_limit_exceeded"}}
+                      :message "OpenAI response status: 429"}]
+      (is (= {:error/type :rate-limited}
+             (llm-providers.errors/classify-error error-data)))
+      (is (true? (llm-providers.errors/retryable? error-data))))))
+
 (deftest classify-error-auth-test
   (testing "401 unauthorized"
     (is (= {:error/type :auth}


### PR DESCRIPTION
## Summary

- Classify known provider quota and billing 429 codes as `:quota-exhausted` before the generic rate-limit fallback.
- Keep ordinary `rate_limit_exceeded` responses retryable.
- Cover structured bodies, message-only failures, OpenAI Responses errors, and the no-retry path.

Closes #405.

## AI assistance

This PR was prepared with OpenAI Codex. The validation commands below were run in the contribution worktree.

## Validation

- `clojure -M:test --focus eca.llm-providers.errors-test --focus eca.llm-api-test` — 50 tests, 541 assertions, 0 failures.
- `clj-kondo --lint src/eca/llm_providers/errors.clj test/eca/llm_providers/errors_test.clj test/eca/llm_api_test.clj` — 0 errors, 0 warnings.
- `clojure -M:test` — 918 tests, 5,158 assertions, 0 failures; one unrelated `babashka.fs` class-cast error in `eca.features.hooks-test/hook-file-resolution-test`, reproduced on pristine `master` with local JDK 26.

- [x] I added a entry in changelog under unreleased section.
- [ ] This is not an AI slop.
