### PR TITLE
feat: add /agent command for current chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `/agent` to switch a chat's primary agent without resetting its established model or variant. #428
 - Add `gpt-6-astra` support: built-in variants `low`, `medium`, `high`, `xhigh`, `max` (no `none`), Codex Lite/context fallbacks, web search and image generation.
 
 ## 0.158.1

--- a/docs/features.md
+++ b/docs/features.md
@@ -129,6 +129,7 @@ The built-in commands are:
 - `/init`: Create/update the AGENTS.md file with details about the workspace for best LLM output quality.
 - `/login`: Log into a provider. Ex: `github-copilot`, `anthropic`.
 - `/model`: Select model for current chat directly from chat. Ex: `anthropic/claude-sonnet-4-6`.
+- `/agent`: Select a primary agent for the current chat. Ex: `plan`.
 - `/skills`: List known skills that ECA can load.
 - `/hooks`: List active hooks grouped by type, showing name, description, and matcher.
 - `/compact`: Compact/summarize conversation helping reduce context window.

--- a/integration-test/integration/chat/commands_test.clj
+++ b/integration-test/integration/chat/commands_test.clj
@@ -25,6 +25,7 @@
             :commands [{:name "init" :arguments []}
                        {:name "login" :arguments [{:name "provider-id"}]}
                        {:name "model" :arguments [{:name "full-model"}]}
+                       {:name "agent" :arguments [{:name "agent-name"}]}
                        {:name "skills" :arguments []}
                        {:name "skill-create"
                         :arguments [{:name "name" :description "The skill name" :required true}

--- a/src/eca/features/commands.clj
+++ b/src/eca/features/commands.clj
@@ -195,6 +195,10 @@
                        :type :native
                        :description "Select model for current chat (Ex: /model anthropic/claude-sonnet-4-6)"
                        :arguments [{:name "full-model"}]}
+                      {:name "agent"
+                       :type :native
+                       :description "Select agent for current chat (Ex: /agent plan)"
+                       :arguments [{:name "agent-name"}]}
                       {:name "skills"
                        :type :native
                        :description "List available skills"
@@ -733,6 +737,43 @@
                     (chat-message
                      (multi-str (str "Selected model: `" selected-model "`")
                                 "Using model defaults.")))))
+      "agent" (let [selected-agent (first args)
+                    available-agents (sort (config/primary-agent-names config))
+                    current-agent (or (get-in db [:chats chat-id :agent]) agent)
+                    chat-message (fn [text]
+                                   {:type :chat-messages
+                                    :chats {chat-id {:messages [{:role "system"
+                                                                 :content [{:type :text
+                                                                            :text text}]}]}}})]
+                (cond
+                  (string/blank? selected-agent)
+                  (if (seq available-agents)
+                    (chat-message
+                     (multi-str (str "Current agent: `" current-agent "`")
+                                ""
+                                "Available agents:"
+                                (string/join "\n" (map #(str "- `" % "`") available-agents))
+                                ""
+                                "Run `/agent <agent-name>` to switch chat agent."))
+                    (chat-message "No primary agents are available."))
+
+                  (not (some #{selected-agent} available-agents))
+                  (chat-message
+                   (multi-str (str "Unknown agent: `" selected-agent "`")
+                              ""
+                              (when (seq available-agents)
+                                (str "Available agents:\n"
+                                     (string/join "\n" (map #(str "- `" % "`") available-agents))))))
+
+                  :else
+                  (do
+                    ;; Reuse the client-selection handler so command selection
+                    ;; persists per-chat, preserves existing model/variant policy,
+                    ;; and refreshes tools exactly like a client-side agent change.
+                    ((requiring-resolve 'eca.handlers/chat-selected-agent-changed)
+                     (select-keys chat-ctx [:db* :messenger :config :metrics])
+                     {:chat-id chat-id :agent selected-agent})
+                    (chat-message (str "Selected agent: `" selected-agent "`.")))))
       "fork" (let [chat (get-in db [:chats chat-id])
                    {new-id :id new-title :title new-messages :messages}
                    (fork-chat! chat (fork-title (:title chat)) [] chat-ctx)]

--- a/test/eca/features/commands_test.clj
+++ b/test/eca/features/commands_test.clj
@@ -375,6 +375,15 @@
                   %)
               commands))))
 
+(deftest all-commands-include-agent-command-test
+  (let [commands (f.commands/all-commands {:workspace-folders []} {})]
+    (is (some #(= {:name "agent"
+                   :type :native
+                   :description "Select agent for current chat (Ex: /agent plan)"
+                   :arguments [{:name "agent-name"}]}
+                 %)
+              commands))))
+
 (deftest handle-sync-system-prompt-command-test
   (testing "clears the chat prompt cache and confirms"
     (swap! (h/db*) assoc-in [:chats "chat-1" :prompt-cache] {:static "old"
@@ -466,6 +475,54 @@
                                               :metrics (h/metrics)})]
       (is (re-find #"Unknown model: `bad/model`"
                    (get-in result [:chats "chat-1" :messages 0 :content 0 :text]))))))
+
+(deftest handle-agent-command-test
+  (testing "lists the current and selectable primary agents"
+    (h/reset-components!)
+    (h/config! {:agent {"code" {}
+                        "plan" {:mode "primary"}
+                        "reviewer" {:mode "subagent"}}})
+    (swap! (h/db*) assoc :chats {"chat-1" {:id "chat-1" :agent "code"}})
+    (let [result (f.commands/handle-command! "agent" [] (command-context "chat-1"))
+          text (get-in result [:chats "chat-1" :messages 0 :content 0 :text])]
+      (is (string/includes? text "Current agent: `code`"))
+      (is (string/includes? text "- `plan`"))
+      (is (not (string/includes? text "reviewer")))))
+
+  (testing "selecting an agent delegates to chat/selectedAgentChanged policy"
+    (h/reset-components!)
+    (h/config! {:providers {"openai" {:models {"gpt-4.1" {:variants {"low" {:effort "low"}
+                                                                         "high" {:effort "high"}}}}}}
+                :agent {"code" {}
+                        "plan" {:defaultModel "anthropic/claude-sonnet-4-5"
+                                :variant "high"}}})
+    (swap! (h/db*) assoc
+           :chats {"chat-1" {:id "chat-1"
+                              :agent "code"
+                              :model "openai/gpt-4.1"
+                              :variant "low"}})
+    (let [result (f.commands/handle-command! "agent" ["plan"] (command-context "chat-1"))]
+      (is (= "plan" (get-in (h/db) [:chats "chat-1" :agent])))
+      (is (= "openai/gpt-4.1" (get-in (h/db) [:chats "chat-1" :model]))
+          "keeps an established model instead of applying the new agent default")
+      (is (= "high" (get-in (h/db) [:chats "chat-1" :variant])))
+      (is (= "chat-1" (get-in (h/messages) [:config-updated 0 :chat-id])))
+      (is (= "openai/gpt-4.1" (get-in (h/messages) [:config-updated 0 :chat :select-model])))
+      (is (= ["high" "low"] (get-in (h/messages) [:config-updated 0 :chat :variants])))
+      (is (= "high" (get-in (h/messages) [:config-updated 0 :chat :select-variant])))
+      (is (= "Selected agent: `plan`."
+             (get-in result [:chats "chat-1" :messages 0 :content 0 :text]))))
+
+  (testing "unknown and subagent-only names do not change chat state"
+    (h/reset-components!)
+    (h/config! {:agent {"code" {}
+                        "worker" {:mode "subagent"}}})
+    (swap! (h/db*) assoc :chats {"chat-1" {:id "chat-1" :agent "code"}})
+    (let [result (f.commands/handle-command! "agent" ["worker"] (command-context "chat-1"))]
+      (is (= "code" (get-in (h/db) [:chats "chat-1" :agent])))
+      (is (empty? (:config-updated (h/messages))))
+      (is (string/includes? (get-in result [:chats "chat-1" :messages 0 :content 0 :text])
+                            "Unknown agent: `worker`"))))))
 
 (deftest restore-command-selection-scoping-test
   (testing "/resume scopes restored selection to the current chat"


### PR DESCRIPTION
## Summary

- Add `/agent [agent-name]` to list and select primary agents from a chat.
- Route valid selections through the existing `chat/selectedAgentChanged` handler so updates stay chat-scoped, refresh tools, and retain its established model and variant policy.
- Document the command, cover its state and validation behavior, and register it in the Unreleased changelog.

## Validation

- `clojure -M:test` — 919 tests, 5163 assertions, 0 failures (JDK 21)
- `clojure -M:test --focus eca.features.commands-test --focus eca.handlers-test` — 37 tests, 274 assertions, 0 failures
- `bb integration-test --dev --ns integration.chat.commands-test` — 4 tests, 74 assertions, 0 failures
- `clj-kondo --lint src/eca/features/commands.clj test/eca/features/commands_test.clj integration-test/integration/chat/commands_test.clj` — clean

The repository-wide `clj-kondo --lint src test dev integration-test` still reports the pre-existing unresolved `dir` symbol in `test/eca/features/hooks_test.clj`; the same error is present on clean upstream master.

AI assistance was used to draft the implementation and tests.

- [x] I added a entry in changelog under unreleased section.
- [ ] This is not an AI slop.
