### PR TITLE
Fix workspace URI paths with square brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Accept unescaped square brackets in workspace file URI paths. #594
 - Recover Anthropic streaming responses interrupted by transient TLS `bad_record_mac` failures.
 - BREAKING: `plugins.install` now appends across config layers. Set `plugins.installMode` to `replace` beside the list to exclude inherited plugins as before.
 

--- a/src/eca/shared.clj
+++ b/src/eca/shared.clj
@@ -203,9 +203,19 @@
       (string/blank? path) base
       :else (str base "/" path))))
 
+(defn ^:private escape-raw-file-uri-path-brackets [uri]
+  (let [[_ prefix path] (re-matches #"(?is)(file:(?://[^/]*)?)(/.*)" uri)
+        escape-brackets #(-> %
+                             (string/replace "[" "%5B")
+                             (string/replace "]" "%5D"))]
+    (if path
+      (str prefix (escape-brackets path))
+      (escape-brackets uri))))
+
 (defn uri->filename [uri]
   (let [^URI uri (-> uri
                      (string/replace " " "%20")
+                     escape-raw-file-uri-path-brackets
                      (URI.))]
     (-> (Paths/get uri) .toString
         ;; WINDOWS drive letters

--- a/test/eca/shared_test.clj
+++ b/test/eca/shared_test.clj
@@ -19,7 +19,12 @@
            (when h/windows? (shared/uri->filename "file:///c:/c.clj")))))
   (testing "Spaces"
     (is (= (h/file-path "/Users/foo/Library/Some Document/comappleCloudDocs")
-           (shared/uri->filename (h/file-uri "file:///Users/foo/Library/Some Document/comappleCloudDocs"))))))
+           (shared/uri->filename (h/file-uri "file:///Users/foo/Library/Some Document/comappleCloudDocs")))))
+  (testing "Raw square brackets"
+    (is (= (h/file-path "/path/[workspace")
+           (shared/uri->filename (h/file-uri "file:///path/[workspace"))))
+    (is (= (h/file-path "/path/workspace]")
+           (shared/uri->filename (h/file-uri "file:///path/workspace]"))))))
 
 (deftest assoc-some-test
   (testing "single association"


### PR DESCRIPTION
Fixes #594.

Some editor clients send workspace file URIs with raw square brackets. `java.net.URI` rejects those characters, causing initialization to fail before the workspace can be opened. This change percent-encodes raw brackets only in the URI path before parsing, while preserving bracketed authorities.

Regression coverage exercises raw unmatched opening and closing brackets through the cross-platform URI-to-filename helper.

Validation:
- Red-before focused regression: 2 `URISyntaxException` errors
- `clojure -M:test --focus eca.shared-test` — 21 tests, 117 assertions
- `bb test` — 931 tests, 5,365 assertions
- Direct `handlers/initialize` reproduction with `file:///tmp/work[one]` succeeds
- Changed-file clj-kondo — 0 errors; only the existing always-true warning in `shared.clj`

Implementation assistance: OpenAI Codex.

- [x] I added a entry in changelog under unreleased section.
- [x] This is not an AI slop.